### PR TITLE
Get rid of all uses of "failwith"

### DIFF
--- a/sihl_core/lib/config.ml
+++ b/sihl_core/lib/config.ml
@@ -197,7 +197,8 @@ let read_string ?default key =
   match (default, value) with
   | _, Some value -> value
   | Some default, None -> default
-  | None, None -> failwith @@ "configuration " ^ key ^ " not found"
+  | None, None ->
+      Fail.raise_configuration @@ "configuration " ^ key ^ " not found"
 
 let read_int ?default key =
   let value = Map.find (State.get ()) key in
@@ -205,9 +206,11 @@ let read_int ?default key =
   | _, Some value -> (
       match Option.try_with (fun () -> Base.Int.of_string value) with
       | Some value -> value
-      | None -> failwith @@ "configuration " ^ key ^ " is not a int" )
+      | None ->
+          Fail.raise_configuration @@ "configuration " ^ key ^ " is not a int" )
   | Some default, None -> default
-  | None, None -> failwith @@ "configuration " ^ key ^ " not found"
+  | None, None ->
+      Fail.raise_configuration @@ "configuration " ^ key ^ " not found"
 
 let read_bool ?default key =
   let value = Map.find (State.get ()) key in
@@ -215,6 +218,8 @@ let read_bool ?default key =
   | _, Some value -> (
       match Caml.bool_of_string_opt value with
       | Some value -> value
-      | None -> failwith @@ "configuration " ^ key ^ " is not a int" )
+      | None ->
+          Fail.raise_configuration @@ "configuration " ^ key ^ " is not a int" )
   | Some default, None -> default
-  | None, None -> failwith @@ "configuration " ^ key ^ " not found"
+  | None, None ->
+      Fail.raise_configuration @@ "configuration " ^ key ^ " not found"

--- a/sihl_core/lib/db.ml
+++ b/sihl_core/lib/db.ml
@@ -22,7 +22,7 @@ let connect () =
   |> Caqti_lwt.connect_pool ~max_size:pool_size
   |> function
   | Ok pool -> pool
-  | Error err -> failwith (Caqti_error.show err)
+  | Error err -> Fail.raise_database (Caqti_error.show err)
 
 (* [query_pool query pool] is the [Ok res] of the [res] obtained by executing
    the database [query], or else the [Error err] reporting the error causing
@@ -63,7 +63,7 @@ let request_with_connection request =
   let connection =
     connection |> function
     | Ok connection -> connection
-    | Error err -> failwith (Caqti_error.show err)
+    | Error err -> Fail.raise_database (Caqti_error.show err)
   in
   let env = Opium.Hmap.add key connection (Request.env request) in
   Lwt.return @@ { request with env }
@@ -89,7 +89,7 @@ let middleware app =
     in
     match !response_ref with
     | Some response -> Lwt.return response
-    | None -> failwith "error happened"
+    | None -> Fail.raise_database "error happened"
   in
   let m = Rock.Middleware.create ~name:"database connection" ~filter in
   Opium.Std.middleware m app

--- a/sihl_core/lib/fail.ml
+++ b/sihl_core/lib/fail.ml
@@ -72,6 +72,8 @@ let raise_database msg = raise @@ Exception.Database msg
 
 let raise_server msg = raise @@ Exception.Server msg
 
+let raise_configuration msg = raise @@ Exception.Configuration msg
+
 let with_bad_request msg result =
   match result with
   | Ok result -> result


### PR DESCRIPTION
It is only allowed to throw Sihl specific errors so we get descriptive
error messages.