### PR TITLE
Implement support for $PORT

### DIFF
--- a/sihl_core/lib/config.ml
+++ b/sihl_core/lib/config.ml
@@ -194,7 +194,9 @@ let load_config schemas setting =
   process schemas setting |> Fail.with_configuration |> State.set |> ignore
 
 let read_string ?default key =
-  let value = Map.find (State.get ()) key in
+  let value =
+    Option.first_some (Map.find (State.get ()) key) (Sys.getenv key)
+  in
   match (default, value) with
   | _, Some value -> value
   | Some default, None -> default
@@ -202,7 +204,9 @@ let read_string ?default key =
       Fail.raise_configuration @@ "configuration " ^ key ^ " not found"
 
 let read_int ?default key =
-  let value = Map.find (State.get ()) key in
+  let value =
+    Option.first_some (Map.find (State.get ()) key) (Sys.getenv key)
+  in
   match (default, value) with
   | _, Some value -> (
       match Option.try_with (fun () -> Base.Int.of_string value) with
@@ -214,7 +218,9 @@ let read_int ?default key =
       Fail.raise_configuration @@ "configuration " ^ key ^ " not found"
 
 let read_bool ?default key =
-  let value = Map.find (State.get ()) key in
+  let value =
+    Option.first_some (Map.find (State.get ()) key) (Sys.getenv key)
+  in
   match (default, value) with
   | _, Some value -> (
       match Caml.bool_of_string_opt value with

--- a/sihl_core/lib/run.ml
+++ b/sihl_core/lib/run.ml
@@ -71,9 +71,10 @@ module Project : PROJECT = struct
     let static_files_path =
       Config.read_string ~default:"./static" "STATIC_FILES_DIR"
     in
-    Logs.debug (fun m -> m "http server starting");
+    let port = Config.read_int ~default:3000 "PORT" in
+    Logs.debug (fun m -> m "http server starting on port %i" port);
     let app =
-      Opium.Std.App.empty
+      Opium.Std.App.empty |> Opium.Std.App.port port
       |> Opium.Std.App.cmd_name "Project"
       |> Opium.Std.middleware Opium.Std.Cookie.m
       |> Opium.Std.middleware


### PR DESCRIPTION
Fixed the issue where Sihl can not read env vars that were not defined
in the config schema.