### PR TITLE
Get rid of caqti-driver-* as dependency so users have to take care

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
             opam pin add -y -n sihl_user .
       - run:
           name: Install system dependencies
-          command: opam depext -y sihl_core sihl_user
+          command: |
+            sudo apt-get install libmariadbclient-dev libpq-dev
+            opam depext -y sihl_core sihl_user
       - run:
           name: Install OCaml dependencies
           command: opam install --deps-only -y sihl_core sihl_user
@@ -39,7 +41,6 @@ jobs:
           command: opam config exec -- make
       - run:
           name: Install OCaml test dependencies
-          # Not using opam install -y -t because it tries to run csv's tests
           command: opam install -y alcotest alcotest-lwt cohttp-lwt-unix caqti-driver-postgresql caqti-driver-mariadb
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Install OCaml test dependencies
           # Not using opam install -y -t because it tries to run csv's tests
-          command: opam install -y alcotest alcotest-lwt cohttp-lwt-unix
+          command: opam install -y alcotest alcotest-lwt cohttp-lwt-unix caqti-driver-postgresql caqti-driver-mariadb
       - run:
           name: Test
           command: opam config exec -- make test-all

--- a/dune-project
+++ b/dune-project
@@ -33,9 +33,6 @@
   ;; Database interface
   (caqti (>= 1.2.1))
   (caqti-lwt (>= 1.2.0))
-  (caqti-driver-postgresql (>= 1.2.1))
-  (caqti-driver-mariadb (>= 1.2.1))
-  (ppx_rapper (>= 0.9.2))
 
   ;; HTML generation
   (tyxml (>= 4.3.0))

--- a/sihl_core.opam
+++ b/sihl_core.opam
@@ -20,9 +20,6 @@ depends: [
   "ppx_deriving_yojson" {>= "3.5.2"}
   "caqti" {>= "1.2.1"}
   "caqti-lwt" {>= "1.2.0"}
-  "caqti-driver-postgresql" {>= "1.2.1"}
-  "caqti-driver-mariadb" {>= "1.2.1"}
-  "ppx_rapper" {>= "0.9.2"}
   "tyxml" {>= "4.3.0"}
   "tyxml-ppx" {>= "4.3.0"}
   "logs" {>= "0.7.0"}

--- a/sihl_core/lib/dune
+++ b/sihl_core/lib/dune
@@ -8,8 +8,6 @@
   opium
   caqti
   caqti-lwt
-  caqti-driver-postgresql
-  caqti-driver-mariadb
   tyxml
   lwt.unix
   yojson

--- a/sihl_email/test/dune
+++ b/sihl_email/test/dune
@@ -3,6 +3,8 @@
  (libraries
   base
   sihl_email
+  caqti-driver-postgresql
+  caqti-driver-mariadb
   alcotest
   alcotest-lwt
 )

--- a/sihl_user/bin/dune
+++ b/sihl_user/bin/dune
@@ -3,6 +3,8 @@
  (libraries
   base
   sihl_user
+  caqti-driver-postgresql
+  caqti-driver-mariadb
   alcotest
   alcotest-lwt
   )

--- a/sihl_user/test/dune
+++ b/sihl_user/test/dune
@@ -3,6 +3,8 @@
  (libraries
   base
   sihl_user
+  caqti-driver-postgresql
+  caqti-driver-mariadb
   alcotest
   alcotest-lwt
   )


### PR DESCRIPTION
This gets rid of the dependency to the C wrappers and we have to
mention that in the documentation.