### PR TITLE
Get rid of unnecessary labeled arguments

### DIFF
--- a/src/token/token_service.ml
+++ b/src/token/token_service.ml
@@ -11,10 +11,10 @@ module Make (Repo : Token_sig.REPOSITORY) : Token_sig.SERVICE = struct
         |> Lwt.map (fun () -> ctx))
       (fun _ -> Lwt.return ())
 
-  let find_opt ctx ~value () = Repo.find_opt ctx ~value
+  let find_opt ctx value = Repo.find_opt ctx ~value
 
-  let find ctx ~value () =
-    let* token = find_opt ctx ~value () in
+  let find ctx value =
+    let* token = find_opt ctx value in
     token
     |> Result.of_option ~error:(Printf.sprintf "Token %s not found" value)
     |> Result.ok_or_failwith |> Lwt.return
@@ -25,5 +25,5 @@ module Make (Repo : Token_sig.REPOSITORY) : Token_sig.SERVICE = struct
     let token = Token_core.make ~id ~kind ~data ~expires_in () in
     let* () = Repo.insert ctx ~token in
     let value = Token_core.value token in
-    find ctx ~value ()
+    find ctx value
 end

--- a/src/token/token_sig.ml
+++ b/src/token/token_sig.ml
@@ -24,9 +24,9 @@ module type SERVICE = sig
       Provide [data] to store optional data as string.
 *)
 
-  val find : Core.Ctx.t -> value:string -> unit -> Token_core.t Lwt.t
+  val find : Core.Ctx.t -> string -> Token_core.t Lwt.t
   (** Returns an active and non-expired token. *)
 
-  val find_opt : Core.Ctx.t -> value:string -> unit -> Token_core.t option Lwt.t
+  val find_opt : Core.Ctx.t -> string -> Token_core.t option Lwt.t
   (** Returns an active and non-expired token. *)
 end

--- a/src/user/user_password_reset_service.ml
+++ b/src/user/user_password_reset_service.ml
@@ -34,7 +34,7 @@ module Make (TokenService : Token.Sig.SERVICE) (UserService : User_sig.SERVICE) 
         Lwt.return None
 
   let reset_password ctx ~token ~password ~password_confirmation =
-    let* token = TokenService.find_opt ctx ~value:token () in
+    let* token = TokenService.find_opt ctx token in
     let token =
       Result.of_option ~error:"Invalid or expired token provided" token
     in

--- a/test/test-common/test_token.ml
+++ b/test/test-common/test_token.ml
@@ -12,7 +12,7 @@ struct
     let* () = RepoService.clean_all ctx in
     let* created = TokenService.create ctx ~kind:"test" ~data:"foo" () in
     let created_value = Sihl.Token.value created in
-    let* found = TokenService.find ctx ~value:created_value () in
+    let* found = TokenService.find ctx created_value in
     let () =
       Alcotest.(check Sihl.Token.alco "Has created session" created found)
     in


### PR DESCRIPTION
Labeled arguments are annoying when you want to partially apply.