### PR TITLE
Add upper bound to letters version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -64,7 +64,7 @@
   (uuidm (>= 0.9.7))
 
   ;; SMTP
-  (letters (>= 0.1.1))
+  (letters (and (>= 0.1.1) (< 0.2.0)))
 
   ;; Helpers & Generation
   (sexplib (>= 0.13.0))

--- a/sihl.opam
+++ b/sihl.opam
@@ -32,7 +32,7 @@ depends: [
   "safepass" {>= "3.0"}
   "jwto" {>= "0.3.0"}
   "uuidm" {>= "0.9.7"}
-  "letters" {>= "0.1.1"}
+  "letters" {>= "0.1.1" & < "0.2.0"}
   "sexplib" {>= "0.13.0"}
   "ppx_fields_conv" {>= "0.13.0"}
   "ppx_sexp_conv" {>= "0.13.0"}


### PR DESCRIPTION
Letters 0.2.0 release is not compatible with the release used here, so
add upper bound to the dependency version.