### PR TITLE
Add support for arbitrary nesting of db service query functions

### DIFF
--- a/src/data/data_db_core.ml
+++ b/src/data/data_db_core.ml
@@ -4,20 +4,32 @@ exception Exception of string
 
 type pool = (Caqti_lwt.connection, Caqti_error.t) Caqti_lwt.Pool.t
 
-let ctx_key_pool : pool Core.Ctx.key = Core.Ctx.create_key ()
-
-let ctx_add_pool pool ctx = Core.Ctx.add ctx_key_pool pool ctx
-
 type connection = (module Caqti_lwt.CONNECTION)
+
+let ctx_key_pool : pool Core.Ctx.key = Core.Ctx.create_key ()
 
 let ctx_key_connection : connection Core.Ctx.key = Core.Ctx.create_key ()
 
-(* let middleware_key_connection : connection Opium.Hmap.key =
- *   Opium.Hmap.Key.create ("connection", fun _ -> sexp_of_string "connection") *)
+let ctx_key_transaction : connection Core.Ctx.key = Core.Ctx.create_key ()
 
-let pool_ref : pool option ref = ref None
+let find_pool ctx = Core.Ctx.find ctx_key_pool ctx
+
+let add_pool pool ctx = Core.Ctx.add ctx_key_pool pool ctx
 
 let remove_pool ctx = Core.Ctx.remove ctx_key_pool ctx
 
+let find_connection ctx = Core.Ctx.find ctx_key_connection ctx
+
 let add_connection connection ctx =
   Core.Ctx.add ctx_key_connection connection ctx
+
+let remove_connection ctx = Core.Ctx.remove ctx_key_connection ctx
+
+let find_transaction ctx = Core.Ctx.find ctx_key_transaction ctx
+
+let add_transaction connection ctx =
+  Core.Ctx.add ctx_key_transaction connection ctx
+
+let remove_transaction ctx = Core.Ctx.remove ctx_key_transaction ctx
+
+let pool_ref : pool option ref = ref None


### PR DESCRIPTION
We track the calls by setting values in the request context. That way
we make sure that for instance there are no nested transactions when
atomic() is called inside another aotmic() call.