### PR TITLE
Make cleaners and migrations registration implicit

### DIFF
--- a/sihl-email/sihl_email.ml
+++ b/sihl-email/sihl_email.ml
@@ -221,7 +221,10 @@ CREATE TABLE IF NOT EXISTS email_templates (
         ;;
       end
 
-      let register_migration () = MigrationService.register (Migration.migration ())
+      let register_migration () =
+        MigrationService.register_migration (Migration.migration ())
+      ;;
+
       let register_cleaner () = Repository.Service.register_cleaner Sql.clean
       let get = Sql.get
       let get_by_name = Sql.get_by_name
@@ -352,7 +355,10 @@ CREATE TABLE IF NOT EXISTS email_templates (
         let migration () = Migration.(empty "email" |> add_step create_templates_table)
       end
 
-      let register_migration () = MigrationService.register (Migration.migration ())
+      let register_migration () =
+        MigrationService.register_migration (Migration.migration ())
+      ;;
+
       let register_cleaner () = Repository.Service.register_cleaner Sql.clean
       let get = Sql.get
       let get_by_name = Sql.get_by_name

--- a/sihl-queue/repo.ml
+++ b/sihl-queue/repo.ml
@@ -201,5 +201,5 @@ CREATE TABLE IF NOT EXISTS queue_jobs (
   end
 
   let register_cleaner () = Repository.Service.register_cleaner clean
-  let register_migration () = MigrationService.register Migration.migration
+  let register_migration () = MigrationService.register_migration Migration.migration
 end

--- a/sihl-storage/repo.ml
+++ b/sihl-storage/repo.ml
@@ -253,7 +253,7 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
       |> add_step create_handles_table)
   ;;
 
-  let register_migration () = MigrationService.register (migration ())
+  let register_migration () = MigrationService.register_migration (migration ())
 
   let register_cleaner () =
     let cleaner ctx =

--- a/sihl/migration/model.ml
+++ b/sihl/migration/model.ml
@@ -34,4 +34,5 @@ module Registry = struct
   let registry : Migration.t list ref = ref []
   let get_all () = !registry
   let register migration = registry := List.concat [ !registry; [ migration ] ]
+  let register_migrations migrations = registry := List.concat [ !registry; migrations ]
 end

--- a/sihl/migration/service.ml
+++ b/sihl/migration/service.ml
@@ -45,7 +45,12 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
     Lwt.return updated_state
   ;;
 
-  let register migration = Model.Registry.register migration |> ignore
+  let register_migration migration = Model.Registry.register migration |> ignore
+
+  let register_migrations migrations =
+    Model.Registry.register_migrations migrations |> ignore
+  ;;
+
   let get_migrations _ = Lwt.return (Model.Registry.get_all ())
 
   let set_fk_check_request =
@@ -178,7 +183,8 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
       ~stop
   ;;
 
-  let configure configuration =
+  let configure migrations configuration =
+    register_migrations migrations;
     let configuration = Core.Configuration.make configuration in
     Core.Container.Service.create ~configuration ~commands:[ migrate_cmd ] lifecycle
   ;;

--- a/sihl/migration/sig.mli
+++ b/sihl/migration/sig.mli
@@ -10,7 +10,10 @@ module type SERVICE = sig
   include Core.Container.Service.Sig
 
   (** Register a migration, so it can be run by the service. *)
-  val register : Model.Migration.t -> unit
+  val register_migration : Model.Migration.t -> unit
+
+  (** Register multiple migrations. *)
+  val register_migrations : Model.Migration.t list -> unit
 
   (** Get all registered migrations. *)
   val get_migrations : Core.Ctx.t -> Model.Migration.t list Lwt.t
@@ -21,5 +24,8 @@ module type SERVICE = sig
   (** Run all registered migrations. *)
   val run_all : Core.Ctx.t -> unit Lwt.t
 
-  val configure : Core.Configuration.data -> Core.Container.Service.t
+  val configure
+    :  Model.Migration.t list
+    -> Core.Configuration.data
+    -> Core.Container.Service.t
 end

--- a/sihl/repository/service.ml
+++ b/sihl/repository/service.ml
@@ -28,7 +28,8 @@ let start ctx = Lwt.return ctx
 let stop _ = Lwt.return ()
 let lifecycle = Core.Container.Lifecycle.create "repo" ~start ~stop
 
-let configure configuration =
+let configure cleaners configuration =
+  register_cleaners cleaners;
   let configuration = Core.Configuration.make configuration in
   Core.Container.Service.create ~configuration lifecycle
 ;;

--- a/sihl/repository/sig.mli
+++ b/sihl/repository/sig.mli
@@ -20,5 +20,8 @@ module type SERVICE = sig
       Use this carefully, running [clean_all] leads to data loss! *)
   val clean_all : Core.Ctx.t -> unit Lwt.t
 
-  val configure : Core.Configuration.data -> Core.Container.Service.t
+  val configure
+    :  Model.cleaner list
+    -> Core.Configuration.data
+    -> Core.Container.Service.t
 end

--- a/sihl/session/repo.ml
+++ b/sihl/session/repo.ml
@@ -123,7 +123,7 @@ CREATE TABLE IF NOT EXISTS session_sessions (
     let migration () = Migration.(empty "session" |> add_step create_sessions_table)
   end
 
-  let register_migration () = MigrationService.register (Migration.migration ())
+  let register_migration () = MigrationService.register_migration (Migration.migration ())
 
   let register_cleaner () =
     let cleaner ctx = Sql.clean ctx in
@@ -262,7 +262,7 @@ CREATE TABLE IF NOT EXISTS session_sessions (
     let migration () = Migration.(empty "session" |> add_step create_sessions_table)
   end
 
-  let register_migration () = MigrationService.register (Migration.migration ())
+  let register_migration () = MigrationService.register_migration (Migration.migration ())
   let register_cleaner () = Repository.Service.register_cleaner Sql.clean
   let find_all = Sql.find_all
   let find_opt = Sql.find_opt

--- a/sihl/token/repo.ml
+++ b/sihl/token/repo.ml
@@ -135,7 +135,7 @@ module MariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPOSITORY = str
     ;;
   end
 
-  let register_migration () = MigrationService.register (Migration.migration ())
+  let register_migration () = MigrationService.register_migration (Migration.migration ())
   let register_cleaner () = Repository.Service.register_cleaner Sql.clean
   let find_opt = Sql.find_opt
   let find_by_id_opt = Sql.find_by_id_opt

--- a/sihl/user/repo.ml
+++ b/sihl/user/repo.ml
@@ -227,7 +227,7 @@ CREATE TABLE IF NOT EXISTS user_users (
         Connection.exec clean_request () |> Lwt.map Result.get_ok)
   ;;
 
-  let register_migration () = MigrationService.register (Migration.migration ())
+  let register_migration () = MigrationService.register_migration (Migration.migration ())
   let register_cleaner () = Repository.Service.register_cleaner clean
 end
 
@@ -423,6 +423,6 @@ CREATE TABLE IF NOT EXISTS user_users (
         Connection.exec clean_request () |> Lwt.map Result.get_ok)
   ;;
 
-  let register_migration () = MigrationService.register (Migration.migration ())
+  let register_migration () = MigrationService.register_migration (Migration.migration ())
   let register_cleaner () = Repository.Service.register_cleaner clean
 end


### PR DESCRIPTION
This is done by passing these to configurations of the repository and
migration services.