### PR TITLE
Remove Core.Ctx.t

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.9] - ?
+### Fixed
+- Get rid of `Core.Ctx.t`
+
 ## [0.1.8] - 2020-11-12
 ### Fixed
 - Get rid of `Result.get_ok` because it swallows errors

--- a/sihl-email/sihl_email_template.ml
+++ b/sihl-email/sihl_email_template.ml
@@ -2,14 +2,14 @@ open Lwt.Syntax
 module Sig = Sihl.Email.Sig
 
 module Make (Repo : Sig.TEMPLATE_REPO) : Sig.TEMPLATE_SERVICE = struct
-  let get ctx ~id = Repo.get ctx ~id
-  let get_by_name ctx ~name = Repo.get_by_name ctx ~name
+  let get ~id = Repo.get ~id
+  let get_by_name ~name = Repo.get_by_name ~name
 
-  let create ctx ~name ~html ~text =
+  let create ~name ~html ~text =
     let template = Sihl.Email.Template.make ~text ~html name in
-    let* () = Repo.insert ctx ~template in
+    let* () = Repo.insert ~template in
     let id = Sihl.Email.Template.id template in
-    let* created = Repo.get ctx ~id in
+    let* created = Repo.get ~id in
     match created with
     | None ->
       Logs.err (fun m ->
@@ -18,10 +18,10 @@ module Make (Repo : Sig.TEMPLATE_REPO) : Sig.TEMPLATE_SERVICE = struct
     | Some created -> Lwt.return created
   ;;
 
-  let update ctx ~template =
-    let* () = Repo.update ctx ~template in
+  let update ~template =
+    let* () = Repo.update ~template in
     let id = Sihl.Email.Template.id template in
-    let* created = Repo.get ctx ~id in
+    let* created = Repo.get ~id in
     match created with
     | None ->
       Logs.err (fun m ->
@@ -30,7 +30,7 @@ module Make (Repo : Sig.TEMPLATE_REPO) : Sig.TEMPLATE_SERVICE = struct
     | Some created -> Lwt.return created
   ;;
 
-  let render ctx email =
+  let render email =
     let template_id = Sihl.Email.template_id email in
     let template_data = Sihl.Email.template_data email in
     let text_content = Sihl.Email.text_content email in
@@ -38,7 +38,7 @@ module Make (Repo : Sig.TEMPLATE_REPO) : Sig.TEMPLATE_SERVICE = struct
     let* text_content, html_content =
       match template_id with
       | Some template_id ->
-        let* template = Repo.get ctx ~id:template_id in
+        let* template = Repo.get ~id:template_id in
         let* template =
           match template with
           | None ->
@@ -56,10 +56,10 @@ module Make (Repo : Sig.TEMPLATE_REPO) : Sig.TEMPLATE_SERVICE = struct
     |> Lwt.return
   ;;
 
-  let start ctx =
+  let start () =
     Repo.register_migration ();
     Repo.register_cleaner ();
-    Lwt.return ctx
+    Lwt.return ()
   ;;
 
   let stop _ = Lwt.return ()
@@ -95,8 +95,8 @@ module Repo = struct
         |sql}
       ;;
 
-      let get ctx ~id =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let get ~id =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.find_opt get_request id
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -123,8 +123,8 @@ module Repo = struct
         |sql}
       ;;
 
-      let get_by_name ctx ~name =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let get_by_name ~name =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.find_opt get_by_name_request name
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -149,8 +149,8 @@ module Repo = struct
         |sql}
       ;;
 
-      let insert ctx ~template =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let insert ~template =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.exec insert_request template
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -169,8 +169,8 @@ module Repo = struct
         |sql}
       ;;
 
-      let update ctx ~template =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let update ~template =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.exec update_request template
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -183,8 +183,8 @@ module Repo = struct
          |sql}
       ;;
 
-      let clean ctx =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let clean () =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.exec clean_request () |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
     end
@@ -252,8 +252,8 @@ CREATE TABLE IF NOT EXISTS email_templates (
         |sql}
       ;;
 
-      let get ctx ~id =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let get ~id =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.find_opt get_request id
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -274,8 +274,8 @@ CREATE TABLE IF NOT EXISTS email_templates (
         |sql}
       ;;
 
-      let get_by_name ctx ~name =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let get_by_name ~name =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.find_opt get_by_name_request name
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -300,8 +300,8 @@ CREATE TABLE IF NOT EXISTS email_templates (
         |sql}
       ;;
 
-      let insert ctx ~template =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let insert ~template =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.exec insert_request template
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -320,8 +320,8 @@ CREATE TABLE IF NOT EXISTS email_templates (
         |sql}
       ;;
 
-      let update ctx ~template =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let update ~template =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.exec update_request template
             |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
@@ -330,8 +330,8 @@ CREATE TABLE IF NOT EXISTS email_templates (
         Caqti_request.exec Caqti_type.unit "TRUNCATE TABLE email_templates CASCADE;"
       ;;
 
-      let clean ctx =
-        Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+      let clean () =
+        Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
             Connection.exec clean_request () |> Lwt.map Sihl.Database.Service.raise_error)
       ;;
     end

--- a/sihl-storage/repo.ml
+++ b/sihl-storage/repo.ml
@@ -46,8 +46,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let insert_file ctx ~file =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let insert_file ~file =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec insert_request file |> Lwt.map Sihl.Database.Service.raise_error)
   ;;
@@ -66,8 +66,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let update_file ctx ~file =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let update_file ~file =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec update_file_request file
         |> Lwt.map Sihl.Database.Service.raise_error)
@@ -89,8 +89,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let get_file ctx ~id =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let get_file ~id =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.find_opt get_file_request id
         |> Lwt.map Sihl.Database.Service.raise_error)
@@ -105,8 +105,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let delete_file ctx ~id =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let delete_file ~id =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec delete_file_request id
         |> Lwt.map Sihl.Database.Service.raise_error)
@@ -124,8 +124,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let get_blob ctx ~id =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let get_blob ~id =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.find_opt get_blob_request id
         |> Lwt.map Sihl.Database.Service.raise_error)
@@ -145,8 +145,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let insert_blob ctx ~id ~blob =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let insert_blob ~id ~blob =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec insert_blob_request (id, blob)
         |> Lwt.map Sihl.Database.Service.raise_error)
@@ -163,8 +163,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let update_blob ctx ~id ~blob =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let update_blob ~id ~blob =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec update_blob_request (id, blob)
         |> Lwt.map Sihl.Database.Service.raise_error)
@@ -180,8 +180,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
          |sql}
   ;;
 
-  let delete_blob ctx ~id =
-    Sihl.Database.Service.query ctx (fun connection ->
+  let delete_blob ~id =
+    Sihl.Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec delete_blob_request id
         |> Lwt.map Sihl.Database.Service.raise_error)
@@ -195,8 +195,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
           |sql}
   ;;
 
-  let clean_handles ctx =
-    Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let clean_handles () =
+    Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec clean_handles_request ()
         |> Lwt.map Sihl.Database.Service.raise_error)
   ;;
@@ -209,8 +209,8 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
           |sql}
   ;;
 
-  let clean_blobs ctx =
-    Sihl.Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let clean_blobs () =
+    Sihl.Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec clean_blobs_request ()
         |> Lwt.map Sihl.Database.Service.raise_error)
   ;;
@@ -269,9 +269,9 @@ module MakeMariaDb (MigrationService : Sihl.Migration.Sig.SERVICE) :
   let register_migration () = MigrationService.register_migration (migration ())
 
   let register_cleaner () =
-    let cleaner ctx =
-      let* () = clean_handles ctx in
-      clean_blobs ctx
+    let cleaner () =
+      let* () = clean_handles () in
+      clean_blobs ()
     in
     Sihl.Repository.Service.register_cleaner cleaner
   ;;

--- a/sihl/authn/service.ml
+++ b/sihl/authn/service.ml
@@ -11,26 +11,26 @@ module Logs = (val Logs.src_log log_src : Logs.LOG)
 
 module Make (SessionService : Session.Sig.SERVICE) (UserService : User.Sig.SERVICE) :
   Sig.SERVICE = struct
-  let find_user_in_session_opt ctx session =
-    let* user_id = SessionService.get ctx session ~key:"authn" in
+  let find_user_in_session_opt session =
+    let* user_id = SessionService.get session ~key:"authn" in
     match user_id with
     | None -> Lwt.return None
-    | Some user_id -> UserService.find_opt ctx ~user_id
+    | Some user_id -> UserService.find_opt ~user_id
   ;;
 
-  let find_user_in_session ctx session =
-    let* user_id = SessionService.get ctx session ~key:"authn" in
+  let find_user_in_session session =
+    let* user_id = SessionService.get session ~key:"authn" in
     match user_id with
     | None -> raise @@ Exception "No user found in current session"
-    | Some user_id -> UserService.find ctx ~user_id
+    | Some user_id -> UserService.find ~user_id
   ;;
 
-  let authenticate_session ctx user session =
-    SessionService.set ctx session ~key:"authn" ~value:(User.id user)
+  let authenticate_session user session =
+    SessionService.set session ~key:"authn" ~value:(User.id user)
   ;;
 
-  let unauthenticate_session ctx session = SessionService.unset ctx session ~key:"authn"
-  let start ctx = Lwt.return ctx
+  let unauthenticate_session session = SessionService.unset session ~key:"authn"
+  let start () = Lwt.return ()
   let stop _ = Lwt.return ()
 
   let lifecycle =

--- a/sihl/authn/sig.mli
+++ b/sihl/authn/sig.mli
@@ -1,6 +1,6 @@
-module Core = Sihl_core
 module Session = Sihl_session
 module User = Sihl_user
+module Core = Sihl_core
 
 module type SERVICE = sig
   include Core.Container.Service.Sig
@@ -9,24 +9,24 @@ module type SERVICE = sig
 
       Make sure to call [authenticate_session] before or apply the required session and
       authentication middlewares. *)
-  val find_user_in_session_opt : Core.Ctx.t -> Session.t -> User.t option Lwt.t
+  val find_user_in_session_opt : Session.t -> User.t option Lwt.t
 
   (** Find currently logged in user in the current context.
 
       Make sure to call [authenticate_session] before or apply the required session and
       authentication middlewares. *)
-  val find_user_in_session : Core.Ctx.t -> Session.t -> User.t Lwt.t
+  val find_user_in_session : Session.t -> User.t Lwt.t
 
   (** Assign a user to the current anonymous session.
 
       Use [authenticate_session ctx user] to log in a [user]. If a user is already
       assigned to session, replace the user. *)
-  val authenticate_session : Core.Ctx.t -> User.t -> Session.t -> unit Lwt.t
+  val authenticate_session : User.t -> Session.t -> unit Lwt.t
 
   (** Log user out.
 
       Remove user from current session so that session is anonymous again. *)
-  val unauthenticate_session : Core.Ctx.t -> Session.t -> unit Lwt.t
+  val unauthenticate_session : Session.t -> unit Lwt.t
 
   val register : unit -> Core.Container.Service.t
 end

--- a/sihl/core/container.mli
+++ b/sihl/core/container.mli
@@ -9,8 +9,8 @@
 
 module Lifecycle : sig
   type t
-  type start = Ctx.t -> Ctx.t Lwt.t
-  type stop = Ctx.t -> unit Lwt.t
+  type start = unit -> unit Lwt.t
+  type stop = unit -> unit Lwt.t
 
   val name : t -> string
   val create : ?dependencies:t list -> string -> start:start -> stop:stop -> t
@@ -40,12 +40,12 @@ end
 (** [start_services lifecycles] starts a list of service [lifecycles]. The order does not
     matter as the services are started in the order of their dependencies. (No service is
     started before its dependency) *)
-val start_services : Service.t list -> (Lifecycle.t list * Ctx.t) Lwt.t
+val start_services : Service.t list -> Lifecycle.t list Lwt.t
 
 (** [stop_services ctx services] stops a list of service [lifecycles] with a context
     [ctx]. The order does not matter as the services are stopped in the order of their
     dependencies. (No service is stopped after its dependency) *)
-val stop_services : Ctx.t -> Service.t list -> unit Lwt.t
+val stop_services : Service.t list -> unit Lwt.t
 
 module Map : sig
   type 'a t

--- a/sihl/database/service.ml
+++ b/sihl/database/service.ml
@@ -57,7 +57,7 @@ let fetch_pool () =
       raise (Exception ("Failed to create pool " ^ msg)))
 ;;
 
-let transaction _ f =
+let transaction f =
   let pool = fetch_pool () in
   print_pool_usage pool;
   let* result =
@@ -104,7 +104,7 @@ let transaction _ f =
     Lwt.fail (Exception msg)
 ;;
 
-let query _ f =
+let query f =
   let pool = fetch_pool () in
   print_pool_usage pool;
   let* result =
@@ -120,10 +120,10 @@ let query _ f =
 
 (* Service lifecycle *)
 
-let start ctx =
+let start () =
   (* Make sure that database is online when starting service. *)
   let _ = fetch_pool () in
-  Lwt.return ctx
+  Lwt.return ()
 ;;
 
 let stop _ = Lwt.return ()

--- a/sihl/database/sig.mli
+++ b/sihl/database/sig.mli
@@ -12,13 +12,13 @@ module type SERVICE = sig
 
   (** [query ctx f] runs the query [f] on the connection pool and returns the result. If
       the query fails the Lwt.t fails as well. *)
-  val query : Core.Ctx.t -> (Caqti_lwt.connection -> 'a Lwt.t) -> 'a Lwt.t
+  val query : (Caqti_lwt.connection -> 'a Lwt.t) -> 'a Lwt.t
 
   (** [transaction ctx f] runs the query [f] on the connection pool in a transaction and
       returns the result. If the query fails the Lwt.t fails as well and the transaction
       gets rolled back. If the database driver doesn't support transactions, [transaction]
       gracefully becomes [query]. *)
-  val transaction : Core.Ctx.t -> (Caqti_lwt.connection -> 'a Lwt.t) -> 'a Lwt.t
+  val transaction : (Caqti_lwt.connection -> 'a Lwt.t) -> 'a Lwt.t
 
   val register : unit -> Core.Container.Service.t
 end

--- a/sihl/email/sig.mli
+++ b/sihl/email/sig.mli
@@ -4,28 +4,21 @@ module Core = Sihl_core
 module type TEMPLATE_SERVICE = sig
   include Core.Container.Service.Sig
 
-  val get : Core.Ctx.t -> id:string -> Model.Template.t option Lwt.t
-  val get_by_name : Core.Ctx.t -> name:string -> Model.Template.t option Lwt.t
-
-  val create
-    :  Core.Ctx.t
-    -> name:string
-    -> html:string
-    -> text:string
-    -> Model.Template.t Lwt.t
-
-  val update : Core.Ctx.t -> template:Model.Template.t -> Model.Template.t Lwt.t
-  val render : Core.Ctx.t -> Model.t -> Model.t Lwt.t
+  val get : id:string -> Model.Template.t option Lwt.t
+  val get_by_name : name:string -> Model.Template.t option Lwt.t
+  val create : name:string -> html:string -> text:string -> Model.Template.t Lwt.t
+  val update : template:Model.Template.t -> Model.Template.t Lwt.t
+  val render : Model.t -> Model.t Lwt.t
   val register : unit -> Core.Container.Service.t
 end
 
 module type TEMPLATE_REPO = sig
   include Repository.Sig.REPO
 
-  val get : Core.Ctx.t -> id:string -> Model.Template.t option Lwt.t
-  val get_by_name : Core.Ctx.t -> name:string -> Model.Template.t option Lwt.t
-  val insert : Core.Ctx.t -> template:Model.Template.t -> unit Lwt.t
-  val update : Core.Ctx.t -> template:Model.Template.t -> unit Lwt.t
+  val get : id:string -> Model.Template.t option Lwt.t
+  val get_by_name : name:string -> Model.Template.t option Lwt.t
+  val insert : template:Model.Template.t -> unit Lwt.t
+  val update : template:Model.Template.t -> unit Lwt.t
 end
 
 module type SERVICE = sig
@@ -35,10 +28,10 @@ module type SERVICE = sig
   module Template : TEMPLATE_SERVICE
 
   (** Send email. *)
-  val send : Core.Ctx.t -> Model.t -> unit Lwt.t
+  val send : Model.t -> unit Lwt.t
 
   (** Send multiple emails. If sending of one of them fails, the function fails.*)
-  val bulk_send : Core.Ctx.t -> Model.t list -> unit Lwt.t
+  val bulk_send : Model.t list -> unit Lwt.t
 
   val register : unit -> Core.Container.Service.t
 end

--- a/sihl/message/sig.mli
+++ b/sihl/message/sig.mli
@@ -2,11 +2,11 @@ module Core = Sihl_core
 module Session = Sihl_session
 
 module type SERVICE = sig
-  val fetch_entry : Core.Ctx.t -> Session.t -> Model.Entry.t option Lwt.t
-  val find_current : Core.Ctx.t -> Session.t -> Model.Message.t option Lwt.t
-  val set_next : Core.Ctx.t -> Session.t -> Model.Message.t -> unit Lwt.t
-  val rotate : Core.Ctx.t -> Session.t -> Model.Message.t option Lwt.t
-  val current : Core.Ctx.t -> Session.t -> Model.Message.t option Lwt.t
+  val fetch_entry : Session.t -> Model.Entry.t option Lwt.t
+  val find_current : Session.t -> Model.Message.t option Lwt.t
+  val set_next : Session.t -> Model.Message.t -> unit Lwt.t
+  val rotate : Session.t -> Model.Message.t option Lwt.t
+  val current : Session.t -> Model.Message.t option Lwt.t
 
   (** Set flash message for the current session.
 
@@ -15,8 +15,7 @@ module type SERVICE = sig
 
       Requires middlewares: Session & Message *)
   val set
-    :  Core.Ctx.t
-    -> Session.t
+    :  Session.t
     -> ?error:string list
     -> ?warning:string list
     -> ?success:string list

--- a/sihl/middleware/middleware_authn.ml
+++ b/sihl/middleware/middleware_authn.ml
@@ -6,10 +6,9 @@ open Lwt.Syntax
 module Make (AuthnService : Authn.Sig.SERVICE) (UserService : User.Sig.SERVICE) = struct
   let session () =
     let filter handler req =
-      let ctx = Http.Request.to_ctx req in
       match Middleware_session.find_opt req with
       | Some session ->
-        let* user = AuthnService.find_user_in_session_opt ctx session in
+        let* user = AuthnService.find_user_in_session_opt session in
         (match user with
         | Some user ->
           let req = Middleware_user.set user req in

--- a/sihl/middleware/middleware_message.ml
+++ b/sihl/middleware/middleware_message.ml
@@ -22,7 +22,6 @@ let set message req =
 module Make (MessageService : Message.Sig.SERVICE) = struct
   let m () =
     let filter handler req =
-      let ctx = Http.Request.to_ctx req in
       let session =
         match Middleware_session.find_opt req with
         | Some session -> session
@@ -31,7 +30,7 @@ module Make (MessageService : Message.Sig.SERVICE) = struct
           Logs.err (fun m -> m "No session found");
           failwith "No session found"
       in
-      let* result = MessageService.rotate ctx session in
+      let* result = MessageService.rotate session in
       match result with
       | Some message ->
         let req = set message req in

--- a/sihl/migration/repo.ml
+++ b/sihl/migration/repo.ml
@@ -14,8 +14,8 @@ CREATE TABLE IF NOT EXISTS core_migration_state (
  |sql}
   ;;
 
-  let create_table_if_not_exists ctx =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let create_table_if_not_exists () =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec create_request () |> Lwt.map Database.Service.raise_error)
   ;;
 
@@ -33,8 +33,8 @@ WHERE namespace = ?;
 |sql}
   ;;
 
-  let get ctx ~namespace =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let get ~namespace =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.find_opt get_request namespace |> Lwt.map Database.Service.raise_error)
     |> Lwt.map (Option.map Model.of_tuple)
   ;;
@@ -57,8 +57,8 @@ dirty = VALUES(dirty)
 |sql}
   ;;
 
-  let upsert ctx ~state =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let upsert ~state =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec upsert_request (Model.to_tuple state)
         |> Lwt.map Database.Service.raise_error)
   ;;
@@ -77,8 +77,8 @@ CREATE TABLE IF NOT EXISTS core_migration_state (
  |sql}
   ;;
 
-  let create_table_if_not_exists ctx =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let create_table_if_not_exists () =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec create_request () |> Lwt.map Database.Service.raise_error)
   ;;
 
@@ -96,8 +96,8 @@ WHERE namespace = ?;
 |sql}
   ;;
 
-  let get ctx ~namespace =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let get ~namespace =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.find_opt get_request namespace |> Lwt.map Database.Service.raise_error)
     |> Lwt.map (Option.map Model.of_tuple)
   ;;
@@ -120,8 +120,8 @@ dirty = EXCLUDED.dirty
 |sql}
   ;;
 
-  let upsert ctx ~state =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let upsert ~state =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec upsert_request (Model.to_tuple state)
         |> Lwt.map Database.Service.raise_error)
   ;;

--- a/sihl/migration/service.ml
+++ b/sihl/migration/service.ml
@@ -17,15 +17,15 @@ let register_migrations migrations =
 ;;
 
 module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
-  let setup ctx =
+  let setup () =
     Logs.debug (fun m -> m "Setting up table if not exists");
-    MigrationRepo.create_table_if_not_exists ctx
+    MigrationRepo.create_table_if_not_exists ()
   ;;
 
-  let has ctx ~namespace = MigrationRepo.get ctx ~namespace |> Lwt.map Option.is_some
+  let has ~namespace = MigrationRepo.get ~namespace |> Lwt.map Option.is_some
 
-  let get ctx ~namespace =
-    let* state = MigrationRepo.get ctx ~namespace in
+  let get ~namespace =
+    let* state = MigrationRepo.get ~namespace in
     Lwt.return
     @@
     match state with
@@ -35,26 +35,26 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
         (Model.Exception (Printf.sprintf "Could not get migration state for %s" namespace))
   ;;
 
-  let upsert ctx state = MigrationRepo.upsert ctx ~state
+  let upsert state = MigrationRepo.upsert ~state
 
-  let mark_dirty ctx ~namespace =
-    let* state = get ctx ~namespace in
+  let mark_dirty ~namespace =
+    let* state = get ~namespace in
     let dirty_state = Model.mark_dirty state in
-    let* () = upsert ctx dirty_state in
+    let* () = upsert dirty_state in
     Lwt.return dirty_state
   ;;
 
-  let mark_clean ctx ~namespace =
-    let* state = get ctx ~namespace in
+  let mark_clean ~namespace =
+    let* state = get ~namespace in
     let clean_state = Model.mark_clean state in
-    let* () = upsert ctx clean_state in
+    let* () = upsert clean_state in
     Lwt.return clean_state
   ;;
 
-  let increment ctx ~namespace =
-    let* state = get ctx ~namespace in
+  let increment ~namespace =
+    let* state = get ~namespace in
     let updated_state = Model.increment state in
-    let* () = upsert ctx updated_state in
+    let* () = upsert updated_state in
     Lwt.return updated_state
   ;;
 
@@ -66,8 +66,8 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
     Caqti_request.exec Caqti_type.bool "SET FOREIGN_KEY_CHECKS = ?;"
   ;;
 
-  let with_disabled_fk_check ctx f =
-    Database.Service.query ctx (fun connection ->
+  let with_disabled_fk_check f =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         let* () =
           Connection.exec set_fk_check_request false
@@ -80,7 +80,7 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
             |> Lwt.map Database.Service.raise_error))
   ;;
 
-  let execute_steps ctx migration =
+  let execute_steps migration =
     let namespace, steps = migration in
     let rec run steps =
       match steps with
@@ -91,13 +91,13 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
           let req = Caqti_request.exec ~oneshot:true Caqti_type.unit statement in
           Connection.exec req () |> Lwt.map Database.Service.raise_error
         in
-        let* () = Database.Service.query ctx query in
+        let* () = Database.Service.query query in
         Logs.debug (fun m -> m "Ran %s" label);
-        let* _ = increment ctx ~namespace in
+        let* _ = increment ~namespace in
         run steps
       | { label; statement; check_fk = false } :: steps ->
         let* () =
-          with_disabled_fk_check ctx (fun connection ->
+          with_disabled_fk_check (fun connection ->
               Logs.debug (fun m -> m "Running %s without fk checks" label);
               let query (module Connection : Caqti_lwt.CONNECTION) =
                 let req = Caqti_request.exec ~oneshot:true Caqti_type.unit statement in
@@ -106,7 +106,7 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
               query connection)
         in
         Logs.debug (fun m -> m "Ran %s" label);
-        let* _ = increment ctx ~namespace in
+        let* _ = increment ~namespace in
         run steps
     in
     let () =
@@ -117,15 +117,15 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
     run steps
   ;;
 
-  let execute_migration ctx migration =
+  let execute_migration migration =
     let namespace, _ = migration in
     Logs.debug (fun m -> m "Execute migrations for %s" namespace);
-    let* () = setup ctx in
-    let* has_state = has ctx ~namespace in
+    let* () = setup () in
+    let* has_state = has ~namespace in
     let* state =
       if has_state
       then
-        let* state = get ctx ~namespace in
+        let* state = get ~namespace in
         if Model.dirty state
         then (
           let msg =
@@ -135,52 +135,51 @@ module Make (MigrationRepo : Sig.REPO) : Sig.SERVICE = struct
           in
           Logs.err (fun m -> m "%s" msg);
           raise (Model.Exception msg))
-        else mark_dirty ctx ~namespace
+        else mark_dirty ~namespace
       else (
         Logs.debug (fun m -> m "Setting up table for %s" namespace);
         let state = Model.create ~namespace in
-        let* () = upsert ctx state in
+        let* () = upsert state in
         Lwt.return state)
     in
     let migration_to_apply = Model.steps_to_apply migration state in
-    let* () = execute_steps ctx migration_to_apply in
-    let* _ = mark_clean ctx ~namespace in
+    let* () = execute_steps migration_to_apply in
+    let* _ = mark_clean ~namespace in
     Lwt.return @@ Ok ()
   ;;
 
-  let execute ctx migrations =
+  let execute migrations =
     let n = List.length migrations in
     if n > 0
     then Logs.debug (fun m -> m "Executing %i migrations" (List.length migrations))
     else Logs.debug (fun m -> m "No migrations to execute");
     let open Lwt in
-    let rec run migrations ctx =
+    let rec run migrations =
       match migrations with
       | [] -> Lwt.return ()
       | migration :: migrations ->
-        execute_migration ctx migration
+        execute_migration migration
         >>= (function
-        | Ok () -> run migrations ctx
+        | Ok () -> run migrations
         | Error err ->
           Logs.err (fun m ->
               m "Error while running migration %a: %s" Model.Migration.pp migration err);
           raise (Model.Exception err))
     in
-    run migrations ctx
+    run migrations
   ;;
 
-  let run_all ctx =
-    let* migrations = get_migrations ctx in
-    execute ctx migrations
+  let run_all () =
+    let* migrations = get_migrations () in
+    execute migrations
   ;;
 
   let migrate_cmd =
     Core.Command.make ~name:"migrate" ~description:"Run all migrations" (fun _ ->
-        let ctx = Core.Ctx.create () in
-        run_all ctx)
+        run_all ())
   ;;
 
-  let start ctx = Lwt.return ctx
+  let start () = Lwt.return ()
   let stop _ = Lwt.return ()
 
   let lifecycle =

--- a/sihl/migration/sig.mli
+++ b/sihl/migration/sig.mli
@@ -2,9 +2,9 @@ module Database = Sihl_database
 module Core = Sihl_core
 
 module type REPO = sig
-  val create_table_if_not_exists : Core.Ctx.t -> unit Lwt.t
-  val get : Core.Ctx.t -> namespace:string -> Model.t option Lwt.t
-  val upsert : Core.Ctx.t -> state:Model.t -> unit Lwt.t
+  val create_table_if_not_exists : unit -> unit Lwt.t
+  val get : namespace:string -> Model.t option Lwt.t
+  val upsert : state:Model.t -> unit Lwt.t
 end
 
 module type SERVICE = sig
@@ -17,13 +17,13 @@ module type SERVICE = sig
   val register_migrations : Model.Migration.t list -> unit
 
   (** Get all registered migrations. *)
-  val get_migrations : Core.Ctx.t -> Model.Migration.t list Lwt.t
+  val get_migrations : unit -> Model.Migration.t list Lwt.t
 
   (** Run a list of migrations. *)
-  val execute : Core.Ctx.t -> Model.Migration.t list -> unit Lwt.t
+  val execute : Model.Migration.t list -> unit Lwt.t
 
   (** Run all registered migrations. *)
-  val run_all : Core.Ctx.t -> unit Lwt.t
+  val run_all : unit -> unit Lwt.t
 
   val register : ?migrations:Model.Migration.t list -> unit -> Core.Container.Service.t
 end

--- a/sihl/password-reset/sig.mli
+++ b/sihl/password-reset/sig.mli
@@ -8,12 +8,11 @@ module type SERVICE = sig
 
       Returns [None] if there is no user with [email]. The reset token can be used with
       [reset_password] to set the password without knowing the old password. *)
-  val create_reset_token : Core.Ctx.t -> email:string -> Token.t option Lwt.t
+  val create_reset_token : email:string -> Token.t option Lwt.t
 
   (** Set the password of a user associated with the reset [token]. *)
   val reset_password
-    :  Core.Ctx.t
-    -> token:string
+    :  token:string
     -> password:string
     -> password_confirmation:string
     -> (unit, string) Result.t Lwt.t

--- a/sihl/queue/sig.mli
+++ b/sihl/queue/sig.mli
@@ -7,9 +7,9 @@ module JobInstance = Model.JobInstance
 module type REPO = sig
   include Repository.Sig.REPO
 
-  val enqueue : Core.Ctx.t -> job_instance:JobInstance.t -> unit Lwt.t
-  val find_workable : Core.Ctx.t -> JobInstance.t list Lwt.t
-  val update : Core.Ctx.t -> job_instance:JobInstance.t -> unit Lwt.t
+  val enqueue : job_instance:JobInstance.t -> unit Lwt.t
+  val find_workable : unit -> JobInstance.t list Lwt.t
+  val update : job_instance:JobInstance.t -> unit Lwt.t
 end
 
 module type SERVICE = sig
@@ -17,18 +17,13 @@ module type SERVICE = sig
 
   (** Queue a [job] for processing. Use [delay] to run the initially job after a certain
       amount of time. *)
-  val dispatch
-    :  Core.Ctx.t
-    -> job:'a Job.t
-    -> ?delay:Utils.Time.duration
-    -> 'a
-    -> unit Lwt.t
+  val dispatch : job:'a Job.t -> ?delay:Utils.Time.duration -> 'a -> unit Lwt.t
 
   (** Register jobs that can be dispatched.
 
       Only registered jobs can be dispatched. Dispatching a job that was not registered
       does nothing. *)
-  val register_jobs : Core.Ctx.t -> jobs:'a Job.t list -> unit Lwt.t
+  val register_jobs : jobs:'a Job.t list -> unit Lwt.t
 
   (* TODO [jerben] hide 'a, so jobs of different type can be configured *)
   val register : ?jobs:'a Job.t list -> unit -> Core.Container.Service.t

--- a/sihl/queue/sihl_queue_core.mli
+++ b/sihl/queue/sihl_queue_core.mli
@@ -10,11 +10,10 @@ module Sig = Sig
 
 val create_job
   :  name:string
-  -> ?with_context:(Core.Ctx.t -> Core.Ctx.t)
   -> input_to_string:('a -> string option)
   -> string_to_input:(string option -> ('a, string) Result.t)
-  -> handle:(Core.Ctx.t -> input:'a -> (unit, string) Result.t Lwt.t)
-  -> ?failed:(Core.Ctx.t -> (unit, string) Result.t Lwt.t)
+  -> handle:(input:'a -> (unit, string) Result.t Lwt.t)
+  -> ?failed:(unit -> (unit, string) Result.t Lwt.t)
   -> unit
   -> 'a Model.Job.t
 

--- a/sihl/repository/model.ml
+++ b/sihl/repository/model.ml
@@ -1,6 +1,4 @@
-module Core = Sihl_core
-
-type cleaner = Core.Ctx.t -> unit Lwt.t
+type cleaner = unit -> unit Lwt.t
 
 module Meta = struct
   type t = { total : int } [@@deriving show, eq, fields, make]

--- a/sihl/repository/service.ml
+++ b/sihl/repository/service.ml
@@ -12,23 +12,23 @@ end
 let register_cleaner cleaner = Registry.register cleaner |> ignore
 let register_cleaners cleaners = Registry.register_cleaners cleaners |> ignore
 
-let clean_all ctx =
+let clean_all () =
   let cleaners = Registry.get_all () in
   let rec clean_repos cleaners =
     match cleaners with
     | [] -> Lwt.return ()
     | cleaner :: cleaners ->
-      let* () = cleaner ctx in
+      let* () = cleaner () in
       clean_repos cleaners
   in
   clean_repos cleaners
 ;;
 
-let start ctx = Lwt.return ctx
+let start () = Lwt.return ()
 let stop _ = Lwt.return ()
-let lifecycle = Core.Container.Lifecycle.create "repo" ~start ~stop
+let lifecycle = Sihl_core.Container.Lifecycle.create "repo" ~start ~stop
 
 let register ?(cleaners = []) () =
   register_cleaners cleaners;
-  Core.Container.Service.create lifecycle
+  Sihl_core.Container.Service.create lifecycle
 ;;

--- a/sihl/repository/sig.mli
+++ b/sihl/repository/sig.mli
@@ -20,7 +20,7 @@ module type SERVICE = sig
   (** Run all registered repository cleaners.
 
       Use this carefully, running [clean_all] leads to data loss! *)
-  val clean_all : Core.Ctx.t -> unit Lwt.t
+  val clean_all : unit -> unit Lwt.t
 
   val register : ?cleaners:Model.cleaner list -> unit -> Core.Container.Service.t
 end

--- a/sihl/session/repo.ml
+++ b/sihl/session/repo.ml
@@ -19,8 +19,8 @@ module MakeMariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = struc
         |sql}
     ;;
 
-    let find_all ctx =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let find_all () =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.collect_list find_all_request ()
           |> Lwt.map Database.Service.raise_error)
     ;;
@@ -39,8 +39,8 @@ module MakeMariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = struc
         |sql}
     ;;
 
-    let find_opt ctx ~key =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let find_opt ~key =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.find_opt find_opt_request key |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -60,8 +60,8 @@ module MakeMariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = struc
         |sql}
     ;;
 
-    let insert ctx session =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let insert session =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec insert_request session |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -76,8 +76,8 @@ module MakeMariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = struc
         |sql}
     ;;
 
-    let update ctx session =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let update session =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec update_request session |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -90,8 +90,8 @@ module MakeMariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = struc
       |sql}
     ;;
 
-    let delete ctx ~key =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let delete ~key =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec delete_request key |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -103,8 +103,8 @@ module MakeMariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = struc
           |sql}
     ;;
 
-    let clean ctx =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let clean () =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec clean_request () |> Lwt.map Database.Service.raise_error)
     ;;
   end
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS session_sessions (
   let register_migration () = MigrationService.register_migration (Migration.migration ())
 
   let register_cleaner () =
-    let cleaner ctx = Sql.clean ctx in
+    let cleaner () = Sql.clean () in
     Repository.Service.register_cleaner cleaner
   ;;
 
@@ -159,8 +159,8 @@ module MakePostgreSql (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = st
         |sql}
     ;;
 
-    let find_all ctx =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let find_all () =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.collect_list find_all_request ()
           |> Lwt.map Database.Service.raise_error)
     ;;
@@ -179,8 +179,8 @@ module MakePostgreSql (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = st
         |sql}
     ;;
 
-    let find_opt ctx ~key =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let find_opt ~key =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.find_opt find_opt_request key |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -200,8 +200,8 @@ module MakePostgreSql (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = st
         |sql}
     ;;
 
-    let insert ctx session =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let insert session =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec insert_request session |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -216,8 +216,8 @@ module MakePostgreSql (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = st
         |sql}
     ;;
 
-    let update ctx session =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let update session =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec update_request session |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -230,8 +230,8 @@ module MakePostgreSql (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = st
            |sql}
     ;;
 
-    let delete ctx ~key =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let delete ~key =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec delete_request key |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -243,8 +243,8 @@ module MakePostgreSql (MigrationService : Migration.Sig.SERVICE) : Sig.REPO = st
         |sql}
     ;;
 
-    let clean ctx =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let clean () =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec clean_request () |> Lwt.map Database.Service.raise_error)
     ;;
   end

--- a/sihl/session/sig.mli
+++ b/sihl/session/sig.mli
@@ -4,23 +4,23 @@ module Core = Sihl_core
 module type REPO = sig
   include Repository.Sig.REPO
 
-  val find_all : Core.Ctx.t -> Model.t list Lwt.t
-  val find_opt : Core.Ctx.t -> key:string -> Model.t option Lwt.t
-  val insert : Core.Ctx.t -> Model.t -> unit Lwt.t
-  val update : Core.Ctx.t -> Model.t -> unit Lwt.t
-  val delete : Core.Ctx.t -> key:string -> unit Lwt.t
+  val find_all : unit -> Model.t list Lwt.t
+  val find_opt : key:string -> Model.t option Lwt.t
+  val insert : Model.t -> unit Lwt.t
+  val update : Model.t -> unit Lwt.t
+  val delete : key:string -> unit Lwt.t
 end
 
 (* TODO document API after reading up on best practices *)
 module type SERVICE = sig
   include Core.Container.Service.Sig
 
-  val create : Core.Ctx.t -> (string * string) list -> Model.t Lwt.t
-  val set : Core.Ctx.t -> Model.t -> key:string -> value:string -> unit Lwt.t
-  val unset : Core.Ctx.t -> Model.t -> key:string -> unit Lwt.t
-  val get : Core.Ctx.t -> Model.t -> key:string -> string option Lwt.t
-  val find_opt : Core.Ctx.t -> key:string -> Model.t option Lwt.t
-  val find : Core.Ctx.t -> key:string -> Model.t Lwt.t
-  val find_all : Core.Ctx.t -> Model.t list Lwt.t
+  val create : (string * string) list -> Model.t Lwt.t
+  val set : Model.t -> key:string -> value:string -> unit Lwt.t
+  val unset : Model.t -> key:string -> unit Lwt.t
+  val get : Model.t -> key:string -> string option Lwt.t
+  val find_opt : key:string -> Model.t option Lwt.t
+  val find : key:string -> Model.t Lwt.t
+  val find_all : unit -> Model.t list Lwt.t
   val register : unit -> Core.Container.Service.t
 end

--- a/sihl/storage/sig.mli
+++ b/sihl/storage/sig.mli
@@ -5,14 +5,14 @@ open Model
 module type REPO = sig
   include Repository.Sig.REPO
 
-  val insert_file : Core.Ctx.t -> file:StoredFile.t -> unit Lwt.t
-  val insert_blob : Core.Ctx.t -> id:string -> blob:string -> unit Lwt.t
-  val get_file : Core.Ctx.t -> id:string -> StoredFile.t option Lwt.t
-  val get_blob : Core.Ctx.t -> id:string -> string option Lwt.t
-  val update_file : Core.Ctx.t -> file:StoredFile.t -> unit Lwt.t
-  val update_blob : Core.Ctx.t -> id:string -> blob:string -> unit Lwt.t
-  val delete_file : Core.Ctx.t -> id:string -> unit Lwt.t
-  val delete_blob : Core.Ctx.t -> id:string -> unit Lwt.t
+  val insert_file : file:StoredFile.t -> unit Lwt.t
+  val insert_blob : id:string -> blob:string -> unit Lwt.t
+  val get_file : id:string -> StoredFile.t option Lwt.t
+  val get_blob : id:string -> string option Lwt.t
+  val update_file : file:StoredFile.t -> unit Lwt.t
+  val update_blob : id:string -> blob:string -> unit Lwt.t
+  val delete_file : id:string -> unit Lwt.t
+  val delete_blob : id:string -> unit Lwt.t
 end
 
 module type SERVICE = sig
@@ -21,24 +21,20 @@ module type SERVICE = sig
   (** Get the meta data of a complete file.
 
       This will not download the content, use [get_data_base64] for that. *)
-  val find_opt : Core.Ctx.t -> id:string -> StoredFile.t option Lwt.t
+  val find_opt : id:string -> StoredFile.t option Lwt.t
 
-  val find : Core.Ctx.t -> id:string -> StoredFile.t Lwt.t
-  val delete : Core.Ctx.t -> id:string -> unit Lwt.t
+  val find : id:string -> StoredFile.t Lwt.t
+  val delete : id:string -> unit Lwt.t
 
   (** Upload base64 string as data content for [file]. *)
-  val upload_base64 : Core.Ctx.t -> file:File.t -> base64:string -> StoredFile.t Lwt.t
+  val upload_base64 : file:File.t -> base64:string -> StoredFile.t Lwt.t
 
   (** Upload and overwrite base64 strong content of [file]. *)
-  val update_base64
-    :  Core.Ctx.t
-    -> file:StoredFile.t
-    -> base64:string
-    -> StoredFile.t Lwt.t
+  val update_base64 : file:StoredFile.t -> base64:string -> StoredFile.t Lwt.t
 
   (** Download actual file content for [file]. *)
-  val download_data_base64_opt : Core.Ctx.t -> file:StoredFile.t -> string option Lwt.t
+  val download_data_base64_opt : file:StoredFile.t -> string option Lwt.t
 
-  val download_data_base64 : Core.Ctx.t -> file:StoredFile.t -> string Lwt.t
+  val download_data_base64 : file:StoredFile.t -> string Lwt.t
   val register : unit -> Core.Container.Service.t
 end

--- a/sihl/token/repo.ml
+++ b/sihl/token/repo.ml
@@ -22,8 +22,8 @@ module MariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPOSITORY = str
         |sql}
     ;;
 
-    let find_opt ctx ~value =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let find_opt ~value =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.find_opt find_request value |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -45,8 +45,8 @@ module MariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPOSITORY = str
         |sql}
     ;;
 
-    let find_by_id_opt ctx ~id =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let find_by_id_opt ~id =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.find_opt find_by_id_request id
           |> Lwt.map Database.Service.raise_error)
     ;;
@@ -75,8 +75,8 @@ module MariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPOSITORY = str
         |sql}
     ;;
 
-    let insert ctx ~token =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let insert ~token =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec insert_request token |> Lwt.map Database.Service.raise_error)
     ;;
 
@@ -95,15 +95,15 @@ module MariaDb (MigrationService : Migration.Sig.SERVICE) : Sig.REPOSITORY = str
         |sql}
     ;;
 
-    let update ctx ~token =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let update ~token =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec update_request token |> Lwt.map Database.Service.raise_error)
     ;;
 
     let clean_request = Caqti_request.exec Caqti_type.unit "TRUNCATE token_tokens;"
 
-    let clean ctx =
-      Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+    let clean () =
+      Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
           Connection.exec clean_request () |> Lwt.map Database.Service.raise_error)
     ;;
   end

--- a/sihl/token/sig.mli
+++ b/sihl/token/sig.mli
@@ -5,10 +5,10 @@ module Repository = Sihl_repository
 module type REPOSITORY = sig
   include Repository.Sig.REPO
 
-  val find_opt : Core.Ctx.t -> value:string -> Model.t option Lwt.t
-  val find_by_id_opt : Core.Ctx.t -> id:string -> Model.t option Lwt.t
-  val insert : Core.Ctx.t -> token:Model.t -> unit Lwt.t
-  val update : Core.Ctx.t -> token:Model.t -> unit Lwt.t
+  val find_opt : value:string -> Model.t option Lwt.t
+  val find_by_id_opt : id:string -> Model.t option Lwt.t
+  val insert : token:Model.t -> unit Lwt.t
+  val update : token:Model.t -> unit Lwt.t
 end
 
 module type SERVICE = sig
@@ -20,8 +20,7 @@ module type SERVICE = sig
       one day. Provide [data] to store optional data as string. Provide [length] to define
       the length of the token in bytes. *)
   val create
-    :  Core.Ctx.t
-    -> kind:string
+    :  kind:string
     -> ?data:string
     -> ?expires_in:Utils.Time.duration
     -> ?length:int
@@ -29,21 +28,21 @@ module type SERVICE = sig
     -> Model.t Lwt.t
 
   (** Returns an active and non-expired token. Raises [Failure] if no token is found. *)
-  val find : Core.Ctx.t -> string -> Model.t Lwt.t
+  val find : string -> Model.t Lwt.t
 
   (** Returns an active and non-expired token. *)
-  val find_opt : Core.Ctx.t -> string -> Model.t option Lwt.t
+  val find_opt : string -> Model.t option Lwt.t
 
   (** Returns an active and non-expired token by id. Raises [Failure] if no token is
       found. *)
-  val find_by_id : Core.Ctx.t -> string -> Model.t Lwt.t
+  val find_by_id : string -> Model.t Lwt.t
 
   (** Returns an active and non-expired token by id. *)
-  val find_by_id_opt : Core.Ctx.t -> string -> Model.t option Lwt.t
+  val find_by_id_opt : string -> Model.t option Lwt.t
 
   (** Invalidate a token by marking it as such in the database and therefore marking it
       "to be deleted" *)
-  val invalidate : Core.Ctx.t -> Model.t -> unit Lwt.t
+  val invalidate : Model.t -> unit Lwt.t
 
   val register : unit -> Core.Container.Service.t
 end

--- a/sihl/user/repo.ml
+++ b/sihl/user/repo.ml
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS user_users (
     ;;
   end
 
-  let get_all ctx ~query =
+  let get_all ~query =
     let fields =
       [ "id"; "email"; "username"; "status"; "admin"; "confirmed"; "created_at" ]
     in
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS user_users (
         sort_fragment
         pagination_fragment
     in
-    Database.Service.query ctx (fun connection ->
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         let request = Caqti_request.collect ~oneshot:true pt Model.t query in
         let* users =
@@ -134,8 +134,8 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let get ctx ~id =
-    Database.Service.query ctx (fun connection ->
+  let get ~id =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.find_opt get_request id |> Lwt.map Database.Service.raise_error)
   ;;
@@ -165,8 +165,8 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let get_by_email ctx ~email =
-    Database.Service.query ctx (fun connection ->
+  let get_by_email ~email =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.find_opt get_by_email_request email
         |> Lwt.map Database.Service.raise_error)
@@ -198,8 +198,8 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let insert ctx ~user =
-    Database.Service.query ctx (fun connection ->
+  let insert ~user =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec insert_request user |> Lwt.map Database.Service.raise_error)
   ;;
@@ -220,16 +220,16 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let update ctx ~user =
-    Database.Service.query ctx (fun connection ->
+  let update ~user =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec update_request user |> Lwt.map Database.Service.raise_error)
   ;;
 
   let clean_request = Caqti_request.exec Caqti_type.unit "TRUNCATE user_users;"
 
-  let clean ctx =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let clean () =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec clean_request () |> Lwt.map Database.Service.raise_error)
   ;;
 
@@ -270,7 +270,7 @@ CREATE TABLE IF NOT EXISTS user_users (
     let migration () = Migration.(empty "user" |> add_step create_users_table)
   end
 
-  let get_all ctx ~query =
+  let get_all ~query =
     let fields =
       [ "id"; "email"; "username"; "status"; "admin"; "confirmed"; "created_at" ]
     in
@@ -306,7 +306,7 @@ CREATE TABLE IF NOT EXISTS user_users (
         sort_fragment
         pagination_fragment
     in
-    Database.Service.query ctx (fun connection ->
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         let request = Caqti_request.collect ~oneshot:true pt Model.t query in
         let* users =
@@ -336,8 +336,8 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let get ctx ~id =
-    Database.Service.query ctx (fun connection ->
+  let get ~id =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.find_opt get_request id |> Lwt.map Database.Service.raise_error)
   ;;
@@ -361,8 +361,8 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let get_by_email ctx ~email =
-    Database.Service.query ctx (fun connection ->
+  let get_by_email ~email =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.find_opt get_by_email_request email
         |> Lwt.map Database.Service.raise_error)
@@ -394,8 +394,8 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let insert ctx ~user =
-    Database.Service.query ctx (fun connection ->
+  let insert ~user =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec insert_request user |> Lwt.map Database.Service.raise_error)
   ;;
@@ -417,8 +417,8 @@ CREATE TABLE IF NOT EXISTS user_users (
         |sql}
   ;;
 
-  let update ctx ~user =
-    Database.Service.query ctx (fun connection ->
+  let update ~user =
+    Database.Service.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
         Connection.exec update_request user |> Lwt.map Database.Service.raise_error)
   ;;
@@ -427,8 +427,8 @@ CREATE TABLE IF NOT EXISTS user_users (
     Caqti_request.exec Caqti_type.unit "TRUNCATE TABLE user_users CASCADE;"
   ;;
 
-  let clean ctx =
-    Database.Service.query ctx (fun (module Connection : Caqti_lwt.CONNECTION) ->
+  let clean () =
+    Database.Service.query (fun (module Connection : Caqti_lwt.CONNECTION) ->
         Connection.exec clean_request () |> Lwt.map Database.Service.raise_error)
   ;;
 

--- a/sihl/user/seed.ml
+++ b/sihl/user/seed.ml
@@ -1,9 +1,7 @@
 module Make (UserService : Sig.SERVICE) = struct
-  let admin ~email ~password request =
-    UserService.create_admin request ~email ~password ~username:None
-  ;;
+  let admin ~email ~password = UserService.create_admin ~email ~password ~username:None
 
-  let user ~email ~password ?username request =
-    UserService.create_user request ~email ~password ~username
+  let user ~email ~password ?username () =
+    UserService.create_user ~email ~password ~username
   ;;
 end

--- a/sihl/user/sig.mli
+++ b/sihl/user/sig.mli
@@ -6,34 +6,24 @@ module type REPOSITORY = sig
   include Repository.Sig.REPO
 
   val lifecycles : Core.Container.Lifecycle.t list
-
-  val get_all
-    :  Core.Ctx.t
-    -> query:Database.Ql.t
-    -> (Model.t list * Repository.Meta.t) Lwt.t
-
-  val get : Core.Ctx.t -> id:string -> Model.t option Lwt.t
-  val get_by_email : Core.Ctx.t -> email:string -> Model.t option Lwt.t
-  val insert : Core.Ctx.t -> user:Model.t -> unit Lwt.t
-  val update : Core.Ctx.t -> user:Model.t -> unit Lwt.t
+  val get_all : query:Database.Ql.t -> (Model.t list * Repository.Meta.t) Lwt.t
+  val get : id:string -> Model.t option Lwt.t
+  val get_by_email : email:string -> Model.t option Lwt.t
+  val insert : user:Model.t -> unit Lwt.t
+  val update : user:Model.t -> unit Lwt.t
 end
 
 module type SERVICE = sig
   include Core.Container.Service.Sig
 
-  val find_all
-    :  Core.Ctx.t
-    -> query:Database.Ql.t
-    -> (Model.t list * Repository.Meta.t) Lwt.t
-
-  val find_opt : Core.Ctx.t -> user_id:string -> Model.t option Lwt.t
-  val find : Core.Ctx.t -> user_id:string -> Model.t Lwt.t
-  val find_by_email : Core.Ctx.t -> email:string -> Model.t Lwt.t
-  val find_by_email_opt : Core.Ctx.t -> email:string -> Model.t option Lwt.t
+  val find_all : query:Database.Ql.t -> (Model.t list * Repository.Meta.t) Lwt.t
+  val find_opt : user_id:string -> Model.t option Lwt.t
+  val find : user_id:string -> Model.t Lwt.t
+  val find_by_email : email:string -> Model.t Lwt.t
+  val find_by_email_opt : email:string -> Model.t option Lwt.t
 
   val update_password
-    :  Core.Ctx.t
-    -> ?password_policy:(string -> (unit, string) Result.t)
+    :  ?password_policy:(string -> (unit, string) Result.t)
     -> user:Model.t
     -> old_password:string
     -> new_password:string
@@ -42,8 +32,7 @@ module type SERVICE = sig
     -> (Model.t, string) Result.t Lwt.t
 
   val update_details
-    :  Core.Ctx.t
-    -> user:Model.t
+    :  user:Model.t
     -> email:string
     -> username:string option
     -> Model.t Lwt.t
@@ -52,8 +41,7 @@ module type SERVICE = sig
 
       This feature is typically used by admins. *)
   val set_password
-    :  Core.Ctx.t
-    -> ?password_policy:(string -> (unit, string) Result.t)
+    :  ?password_policy:(string -> (unit, string) Result.t)
     -> user:Model.t
     -> password:string
     -> password_confirmation:string
@@ -62,16 +50,14 @@ module type SERVICE = sig
 
   (** Create and store a user. *)
   val create_user
-    :  Core.Ctx.t
-    -> email:string
+    :  email:string
     -> password:string
     -> username:string option
     -> Model.t Lwt.t
 
   (** Create and store a user that is also an admin. *)
   val create_admin
-    :  Core.Ctx.t
-    -> email:string
+    :  email:string
     -> password:string
     -> username:string option
     -> Model.t Lwt.t
@@ -80,8 +66,7 @@ module type SERVICE = sig
 
       Provide [password_policy] to check whether the password fulfills certain criteria. *)
   val register_user
-    :  Core.Ctx.t
-    -> ?password_policy:(string -> (unit, string) result)
+    :  ?password_policy:(string -> (unit, string) result)
     -> ?username:string
     -> email:string
     -> password:string
@@ -90,11 +75,7 @@ module type SERVICE = sig
     -> (Model.t, string) Result.t Lwt.t
 
   (** Find user by email if password matches. *)
-  val login
-    :  Core.Ctx.t
-    -> email:string
-    -> password:string
-    -> (Model.t, string) Result.t Lwt.t
+  val login : email:string -> password:string -> (Model.t, string) Result.t Lwt.t
 
   val register : unit -> Core.Container.Service.t
 end

--- a/test/service/cases/csrf.ml
+++ b/test/service/cases/csrf.ml
@@ -18,8 +18,7 @@ struct
 
   let get_request_yields_token _ () =
     let req = Sihl.Http.Request.get "" in
-    let ctx = Sihl.Http.Request.to_ctx req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let handler req =
       let token_value = Sihl.Middleware.Csrf.find req in
       Alcotest.(check bool "Has CSRF token" true (not @@ String.equal "" token_value));
@@ -32,8 +31,7 @@ struct
 
   let get_request_without_token_succeeds _ () =
     let req = Sihl.Http.Request.get "" in
-    let ctx = Sihl.Http.Request.to_ctx req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let handler _ = Lwt.return @@ Sihl.Http.Response.create () in
     let wrapped_handler = apply_middlewares handler in
     let* response = wrapped_handler req in
@@ -44,8 +42,7 @@ struct
 
   let two_get_requests_yield_same_token _ () =
     let req = Sihl.Http.Request.get "" in
-    let ctx = Sihl.Http.Request.to_ctx req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let token_ref1 = ref "" in
     let token_ref2 = ref "" in
     let handler tkn req =
@@ -88,8 +85,7 @@ struct
 
   let post_request_yields_token _ () =
     let post_req = Sihl.Http.Request.post "/foo" in
-    let ctx = Sihl.Http.Request.to_ctx post_req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let handler req =
       let token_value = Sihl.Middleware.Csrf.find req in
       Alcotest.(check bool "Has CSRF token" true (not @@ String.equal "" token_value));
@@ -102,8 +98,7 @@ struct
 
   let post_request_without_token_fails _ () =
     let post_req = Sihl.Http.Request.post "/foo" in
-    let ctx = Sihl.Http.Request.to_ctx post_req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let handler _ = Lwt.return @@ Sihl.Http.Response.create () in
     let wrapped_handler = apply_middlewares handler in
     let* response = wrapped_handler post_req in
@@ -116,8 +111,7 @@ struct
     let post_req =
       Sihl.Http.Request.of_urlencoded ~body:[ "csrf", [ "invalid_token" ] ] "/foo" `POST
     in
-    let ctx = Sihl.Http.Request.to_ctx post_req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let handler _ = Lwt.return @@ Sihl.Http.Response.create () in
     let wrapped_handler = apply_middlewares handler in
     Lwt.catch
@@ -134,8 +128,7 @@ struct
     let post_req =
       Sihl.Http.Request.of_urlencoded ~body:[ "csrf", [ "aGVsbG8=" ] ] "/foo" `POST
     in
-    let ctx = Sihl.Http.Request.to_ctx post_req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let handler _ = Lwt.return @@ Sihl.Http.Response.create () in
     let wrapped_handler = apply_middlewares handler in
     Lwt.catch
@@ -149,8 +142,7 @@ struct
 
   let post_request_with_nonmatching_token_fails _ () =
     let req = Sihl.Http.Request.get "" in
-    let ctx = Sihl.Http.Request.to_ctx req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let token_ref = ref "" in
     let handler req =
       token_ref := Sihl.Middleware.Csrf.find req;
@@ -182,8 +174,7 @@ struct
         "/foo"
         `POST
     in
-    let ctx = Sihl.Http.Request.to_ctx post_req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let handler _ = Lwt.return @@ Sihl.Http.Response.create () in
     let wrapped_handler = apply_middlewares handler in
     let* response = wrapped_handler post_req in
@@ -195,8 +186,7 @@ struct
   let post_request_with_valid_token_succeeds _ () =
     (* Do GET to set a token *)
     let req = Sihl.Http.Request.get "" in
-    let ctx = Sihl.Http.Request.to_ctx req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let token_ref = ref "" in
     let session_req = ref None in
     let handler req =
@@ -227,7 +217,7 @@ struct
     let session = Sihl.Middleware.Session.find req in
     let token_id = Sihl.Session.get "csrf" session in
     let token_id = Option.get token_id in
-    let* token = TokenService.find_by_id_opt ctx token_id in
+    let* token = TokenService.find_by_id_opt token_id in
     Alcotest.(check (option Sihl.Token.alco) "Token is invalidated" None token);
     Lwt.return ()
   ;;

--- a/test/service/cases/database.ml
+++ b/test/service/cases/database.ml
@@ -51,9 +51,8 @@ let get_usernames connection =
 ;;
 
 let query _ () =
-  let ctx = Sihl.Core.Ctx.create () in
   let* usernames =
-    Sihl.Database.Service.query ctx (fun connection ->
+    Sihl.Database.Service.query (fun connection ->
         let* () = drop_table_if_exists connection in
         let* () = create_table_if_not_exists connection in
         let* () = insert_username connection "foobar pool" in
@@ -65,12 +64,11 @@ let query _ () =
 ;;
 
 let query_with_transaction _ () =
-  let ctx = Sihl.Core.Ctx.create () in
   let* usernames =
-    Sihl.Database.Service.query ctx (fun connection ->
+    Sihl.Database.Service.query (fun connection ->
         let* () = drop_table_if_exists connection in
         let* () = create_table_if_not_exists connection in
-        Sihl.Database.Service.transaction ctx (fun connection ->
+        Sihl.Database.Service.transaction (fun connection ->
             let* () = insert_username connection "foobar trx" in
             get_usernames connection))
   in
@@ -80,15 +78,14 @@ let query_with_transaction _ () =
 ;;
 
 let transaction_rolls_back _ () =
-  let ctx = Sihl.Core.Ctx.create () in
   let* usernames =
-    Sihl.Database.Service.query ctx (fun connection ->
+    Sihl.Database.Service.query (fun connection ->
         let* () = drop_table_if_exists connection in
         let* () = create_table_if_not_exists connection in
         let* () =
           Lwt.catch
             (fun () ->
-              Sihl.Database.Service.transaction ctx (fun connection ->
+              Sihl.Database.Service.transaction (fun connection ->
                   let* () = insert_username connection "foobar trx" in
                   failwith "Oh no, something went wrong during the transaction!"))
             (fun _ -> Lwt.return ())

--- a/test/service/cases/email.ml
+++ b/test/service/cases/email.ml
@@ -3,14 +3,13 @@ open Lwt.Syntax
 
 module Make (EmailTemplateService : Sihl.Email.Sig.TEMPLATE_SERVICE) = struct
   let create_template _ () =
-    let ctx = Sihl.Core.Ctx.create () in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let* created =
-      EmailTemplateService.create ctx ~name:"foo" ~html:"some html" ~text:"some text"
+      EmailTemplateService.create ~name:"foo" ~html:"some html" ~text:"some text"
     in
     let id = Sihl.Email.Template.id created in
     let* template =
-      EmailTemplateService.get ctx ~id
+      EmailTemplateService.get ~id
       |> Lwt.map (Option.to_result ~none:"Template not found")
       |> Lwt.map Result.get_ok
     in
@@ -21,13 +20,12 @@ module Make (EmailTemplateService : Sihl.Email.Sig.TEMPLATE_SERVICE) = struct
   ;;
 
   let update_template _ () =
-    let ctx = Sihl.Core.Ctx.create () in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let* created =
-      EmailTemplateService.create ctx ~name:"foo" ~html:"some html" ~text:"some text"
+      EmailTemplateService.create ~name:"foo" ~html:"some html" ~text:"some text"
     in
     let updated = Sihl.Email.Template.set_name "newname" created in
-    let* template = EmailTemplateService.update ctx ~template:updated in
+    let* template = EmailTemplateService.update ~template:updated in
     Alcotest.(check string "name" "newname" (Sihl.Email.Template.name template));
     Lwt.return ()
   ;;

--- a/test/service/cases/password_reset.ml
+++ b/test/service/cases/password_reset.ml
@@ -8,25 +8,23 @@ struct
   module UserSeed = Sihl.User.Seed.Make (UserService)
 
   let reset_password_suceeds _ () =
-    let ctx = Sihl.Core.Ctx.create () in
-    let* () = Sihl.Repository.Service.clean_all ctx in
-    let* _ = UserSeed.user ctx ~email:"foo@example.com" ~password:"123456789" in
+    let* () = Sihl.Repository.Service.clean_all () in
+    let* _ = UserSeed.user () ~email:"foo@example.com" ~password:"123456789" in
     let* token =
-      PasswordResetService.create_reset_token ctx ~email:"foo@example.com"
+      PasswordResetService.create_reset_token ~email:"foo@example.com"
       |> Lwt.map (Option.to_result ~none:"User with email not found")
       |> Lwt.map Result.get_ok
     in
     let token = Sihl.Token.value token in
     let* () =
       PasswordResetService.reset_password
-        ctx
         ~token
         ~password:"newpassword"
         ~password_confirmation:"newpassword"
       |> Lwt.map Result.get_ok
     in
     let* _ =
-      UserService.login ctx ~email:"foo@example.com" ~password:"newpassword"
+      UserService.login ~email:"foo@example.com" ~password:"newpassword"
       |> Lwt.map Result.get_ok
     in
     Lwt.return ()

--- a/test/service/cases/queue.ml
+++ b/test/service/cases/queue.ml
@@ -2,16 +2,16 @@ open Alcotest_lwt
 open Lwt.Syntax
 
 module Make (QueueService : Sihl.Queue.Sig.SERVICE) = struct
-  let dispatched_job_gets_processed ctx _ () =
+  let dispatched_job_gets_processed _ () =
     let has_ran_job = ref false in
-    let* () = Sihl.Core.Container.stop_services ctx [ QueueService.register () ] in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Core.Container.stop_services [ QueueService.register () ] in
+    let* () = Sihl.Repository.Service.clean_all () in
     let job =
       Sihl.Queue.create_job
         ~name:"foo"
         ~input_to_string:(fun _ -> None)
         ~string_to_input:(fun _ -> Ok ())
-        ~handle:(fun _ ~input:_ -> Lwt_result.return (has_ran_job := true))
+        ~handle:(fun ~input:_ -> Lwt_result.return (has_ran_job := true))
         ~failed:(fun _ -> Lwt_result.return ())
         ()
       |> Sihl.Queue.set_max_tries 3
@@ -19,24 +19,24 @@ module Make (QueueService : Sihl.Queue.Sig.SERVICE) = struct
     in
     let service = QueueService.register ~jobs:[ job ] () in
     let* _ = Sihl.Core.Container.start_services [ service ] in
-    let* () = QueueService.dispatch ctx ~job () in
+    let* () = QueueService.dispatch ~job () in
     let* () = Lwt_unix.sleep 2.0 in
-    let* () = Sihl.Core.Container.stop_services ctx [ service ] in
+    let* () = Sihl.Core.Container.stop_services [ service ] in
     let () = Alcotest.(check bool "has processed job" true !has_ran_job) in
     Lwt.return ()
   ;;
 
-  let two_dispatched_jobs_get_processed ctx _ () =
+  let two_dispatched_jobs_get_processed _ () =
     let has_ran_job1 = ref false in
     let has_ran_job2 = ref false in
-    let* () = Sihl.Core.Container.stop_services ctx [ QueueService.register () ] in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Core.Container.stop_services [ QueueService.register () ] in
+    let* () = Sihl.Repository.Service.clean_all () in
     let job1 =
       Sihl.Queue.create_job
         ~name:"foo1"
         ~input_to_string:(fun _ -> None)
         ~string_to_input:(fun _ -> Ok ())
-        ~handle:(fun _ ~input:_ -> Lwt_result.return (has_ran_job1 := true))
+        ~handle:(fun ~input:_ -> Lwt_result.return (has_ran_job1 := true))
         ~failed:(fun _ -> Lwt_result.return ())
         ()
       |> Sihl.Queue.set_max_tries 3
@@ -47,35 +47,35 @@ module Make (QueueService : Sihl.Queue.Sig.SERVICE) = struct
         ~name:"foo2"
         ~input_to_string:(fun _ -> None)
         ~string_to_input:(fun _ -> Ok ())
-        ~handle:(fun _ ~input:_ -> Lwt_result.return (has_ran_job2 := true))
+        ~handle:(fun ~input:_ -> Lwt_result.return (has_ran_job2 := true))
         ~failed:(fun _ -> Lwt_result.return ())
         ()
       |> Sihl.Queue.set_max_tries 3
       |> Sihl.Queue.set_retry_delay Sihl.Utils.Time.OneMinute
     in
-    let* () = QueueService.register_jobs ctx ~jobs:[ job1; job2 ] in
+    let* () = QueueService.register_jobs ~jobs:[ job1; job2 ] in
     let jobs = [ job1; job2 ] in
     let service = QueueService.register ~jobs () in
     let* _ = Sihl.Core.Container.start_services [ service ] in
-    let* () = QueueService.dispatch ctx ~job:job1 () in
-    let* () = QueueService.dispatch ctx ~job:job2 () in
+    let* () = QueueService.dispatch ~job:job1 () in
+    let* () = QueueService.dispatch ~job:job2 () in
     let* () = Lwt_unix.sleep 4.0 in
-    let* () = Sihl.Core.Container.stop_services ctx [ service ] in
+    let* () = Sihl.Core.Container.stop_services [ service ] in
     let () = Alcotest.(check bool "has processed job1" true !has_ran_job1) in
     let () = Alcotest.(check bool "has processed job2" true !has_ran_job1) in
     Lwt.return ()
   ;;
 
-  let cleans_up_job_after_error ctx _ () =
+  let cleans_up_job_after_error _ () =
     let has_cleaned_up_job = ref false in
-    let* () = Sihl.Core.Container.stop_services ctx [ QueueService.register () ] in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Core.Container.stop_services [ QueueService.register () ] in
+    let* () = Sihl.Repository.Service.clean_all () in
     let job =
       Sihl.Queue.create_job
         ~name:"foo"
         ~input_to_string:(fun _ -> None)
         ~string_to_input:(fun _ -> Ok ())
-        ~handle:(fun _ ~input:_ -> Lwt_result.fail "didn't work")
+        ~handle:(fun ~input:_ -> Lwt_result.fail "didn't work")
         ~failed:(fun _ -> Lwt_result.return (has_cleaned_up_job := true))
         ()
       |> Sihl.Queue.set_max_tries 3
@@ -83,86 +83,47 @@ module Make (QueueService : Sihl.Queue.Sig.SERVICE) = struct
     in
     let service = QueueService.register ~jobs:[ job ] () in
     let* _ = Sihl.Core.Container.start_services [ service ] in
-    let* () = QueueService.dispatch ctx ~job () in
+    let* () = QueueService.dispatch ~job () in
     let* () = Lwt_unix.sleep 2.0 in
-    let* () = Sihl.Core.Container.stop_services ctx [ service ] in
+    let* () = Sihl.Core.Container.stop_services [ service ] in
     let () = Alcotest.(check bool "has cleaned up job" true !has_cleaned_up_job) in
     Lwt.return ()
   ;;
 
-  let cleans_up_job_after_exception ctx _ () =
+  let cleans_up_job_after_exception _ () =
     let has_cleaned_up_job = ref false in
-    let* () = Sihl.Core.Container.stop_services ctx [ QueueService.register () ] in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Core.Container.stop_services [ QueueService.register () ] in
+    let* () = Sihl.Repository.Service.clean_all () in
     let job =
       Sihl.Queue.create_job
         ~name:"foo"
         ~input_to_string:(fun _ -> None)
         ~string_to_input:(fun _ -> Ok ())
-        ~handle:(fun _ ~input:_ -> failwith "didn't work")
+        ~handle:(fun ~input:_ -> failwith "didn't work")
         ~failed:(fun _ -> Lwt_result.return (has_cleaned_up_job := true))
         ()
       |> Sihl.Queue.set_max_tries 3
       |> Sihl.Queue.set_retry_delay Sihl.Utils.Time.OneMinute
     in
-    let* () = QueueService.register_jobs ctx ~jobs:[ job ] in
+    let* () = QueueService.register_jobs ~jobs:[ job ] in
     let service = QueueService.register ~jobs:[ job ] () in
     let* _ = Sihl.Core.Container.start_services [ service ] in
-    let* () = QueueService.dispatch ctx ~job () in
+    let* () = QueueService.dispatch ~job () in
     let* () = Lwt_unix.sleep 2.0 in
-    let* () = Sihl.Core.Container.stop_services ctx [ service ] in
+    let* () = Sihl.Core.Container.stop_services [ service ] in
     let () = Alcotest.(check bool "has cleaned up job" true !has_cleaned_up_job) in
     Lwt.return ()
   ;;
 
-  let inject_custom_context ctx _ () =
-    let custom_ctx_key : string Sihl.Core.Ctx.key = Sihl.Core.Ctx.create_key () in
-    let* () = Sihl.Core.Container.stop_services ctx [ QueueService.register () ] in
-    let* () = Sihl.Repository.Service.clean_all ctx in
-    let has_custom_ctx_string = ref false in
-    let custom_with_context ctx =
-      ctx |> fun ctx -> Sihl.Core.Ctx.add custom_ctx_key "my custom context string" ctx
-    in
-    let job =
-      Sihl.Queue.create_job
-        ~name:"foo"
-        ~with_context:custom_with_context
-        ~input_to_string:(fun _ -> None)
-        ~string_to_input:(fun _ -> Ok ())
-        ~handle:(fun ctx ~input:_ ->
-          has_custom_ctx_string := Option.is_some (Sihl.Core.Ctx.find custom_ctx_key ctx);
-          Lwt_result.return ())
-        ~failed:(fun _ -> Lwt_result.return ())
-        ()
-      |> Sihl.Queue.set_max_tries 3
-      |> Sihl.Queue.set_retry_delay Sihl.Utils.Time.OneMinute
-    in
-    let* () = QueueService.register_jobs ctx ~jobs:[ job ] in
-    let service = QueueService.register ~jobs:[ job ] () in
-    let* _ = Sihl.Core.Container.start_services [ service ] in
-    let* () = QueueService.dispatch ctx ~job () in
-    let* () = Lwt_unix.sleep 2.0 in
-    let* () = Sihl.Core.Container.stop_services ctx [ service ] in
-    let () = Alcotest.(check bool "has custom ctx string" true !has_custom_ctx_string) in
-    Lwt.return ()
-  ;;
-
-  let test_suite ctx =
+  let test_suite =
     ( "queue"
-    , [ test_case
-          "dispatched job gets processed"
-          `Quick
-          (dispatched_job_gets_processed ctx)
+    , [ test_case "dispatched job gets processed" `Quick dispatched_job_gets_processed
       ; test_case
           "two dispatched jobs get processed"
           `Quick
-          (two_dispatched_jobs_get_processed ctx)
-      ; test_case "cleans up job after error" `Quick (cleans_up_job_after_error ctx)
-      ; test_case
-          "cleans up job after exception"
-          `Quick
-          (cleans_up_job_after_exception ctx)
-      ; test_case "inject custom context" `Quick (inject_custom_context ctx)
+          two_dispatched_jobs_get_processed
+      ; test_case "cleans up job after error" `Quick cleans_up_job_after_error
+      ; test_case "cleans up job after exception" `Quick cleans_up_job_after_exception
       ] )
   ;;
 end

--- a/test/service/cases/session.ml
+++ b/test/service/cases/session.ml
@@ -6,8 +6,7 @@ module Make (SessionService : Sihl.Session.Sig.SERVICE) = struct
 
   let test_anonymous_request_returns_cookie _ () =
     let req = Sihl.Http.Request.get "" in
-    let ctx = Sihl.Http.Request.to_ctx req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let middleware = Middleware.m () in
     let* _ =
       Opium_kernel.Rock.Middleware.apply
@@ -15,23 +14,22 @@ module Make (SessionService : Sihl.Session.Sig.SERVICE) = struct
         (fun _ -> Lwt.return @@ Sihl.Http.Response.of_plain_text "")
         req
     in
-    let* sessions = SessionService.find_all ctx in
+    let* sessions = SessionService.find_all () in
     let () = Alcotest.(check int "Has created session" 1 (List.length sessions)) in
     Lwt.return ()
   ;;
 
   let test_requests_persist_session_variables _ () =
     let req = Sihl.Http.Request.get "" in
-    let ctx = Sihl.Http.Request.to_ctx req in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let middleware = Middleware.m () in
     let handler req =
       let session = Sihl.Middleware.Session.find req in
-      let* () = SessionService.set ctx session ~key:"foo" ~value:"bar" in
+      let* () = SessionService.set session ~key:"foo" ~value:"bar" in
       Lwt.return @@ Sihl.Http.Response.create ()
     in
     let* _ = Opium_kernel.Rock.Middleware.apply middleware handler req in
-    let* session = SessionService.find_all ctx |> Lwt.map List.hd in
+    let* session = SessionService.find_all () |> Lwt.map List.hd in
     let () =
       Alcotest.(
         check

--- a/test/service/cases/storage.ml
+++ b/test/service/cases/storage.ml
@@ -5,8 +5,7 @@ let alco_file = Alcotest.testable Sihl.Storage.File.pp Sihl.Storage.File.equal
 
 module Make (StorageService : Sihl.Storage.Sig.SERVICE) = struct
   let fetch_uploaded_file _ () =
-    let ctx = Sihl.Core.Ctx.create () in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let file_id = Sihl.Database.Id.(random () |> to_string) in
     let file =
       Sihl.Storage.File.make
@@ -15,18 +14,17 @@ module Make (StorageService : Sihl.Storage.Sig.SERVICE) = struct
         ~filesize:123
         ~mime:"application/pdf"
     in
-    let* _ = StorageService.upload_base64 ctx ~file ~base64:"ZmlsZWNvbnRlbnQ=" in
-    let* uploaded_file = StorageService.find ctx ~id:file_id in
+    let* _ = StorageService.upload_base64 ~file ~base64:"ZmlsZWNvbnRlbnQ=" in
+    let* uploaded_file = StorageService.find ~id:file_id in
     let actual_file = uploaded_file |> Sihl.Storage.StoredFile.file in
     Alcotest.(check alco_file "has same file" file actual_file);
-    let* actual_blob = StorageService.download_data_base64 ctx ~file:uploaded_file in
+    let* actual_blob = StorageService.download_data_base64 ~file:uploaded_file in
     Alcotest.(check string "has same blob" "ZmlsZWNvbnRlbnQ=" actual_blob);
     Lwt.return ()
   ;;
 
   let update_uploaded_file _ () =
-    let ctx = Sihl.Core.Ctx.create () in
-    let* () = Sihl.Repository.Service.clean_all ctx in
+    let* () = Sihl.Repository.Service.clean_all () in
     let file_id = Sihl.Database.Id.(random () |> to_string) in
     let file =
       Sihl.Storage.File.make
@@ -35,14 +33,12 @@ module Make (StorageService : Sihl.Storage.Sig.SERVICE) = struct
         ~filesize:123
         ~mime:"application/pdf"
     in
-    let* stored_file =
-      StorageService.upload_base64 ctx ~file ~base64:"ZmlsZWNvbnRlbnQ="
-    in
+    let* stored_file = StorageService.upload_base64 ~file ~base64:"ZmlsZWNvbnRlbnQ=" in
     let updated_file =
       Sihl.Storage.StoredFile.set_filename "assessment.pdf" stored_file
     in
     let* actual_file =
-      StorageService.update_base64 ctx ~file:updated_file ~base64:"bmV3Y29udGVudA=="
+      StorageService.update_base64 ~file:updated_file ~base64:"bmV3Y29udGVudA=="
     in
     Alcotest.(
       check
@@ -50,7 +46,7 @@ module Make (StorageService : Sihl.Storage.Sig.SERVICE) = struct
         "has updated file"
         (Sihl.Storage.StoredFile.file updated_file)
         (Sihl.Storage.StoredFile.file actual_file));
-    let* actual_blob = StorageService.download_data_base64 ctx ~file:stored_file in
+    let* actual_blob = StorageService.download_data_base64 ~file:stored_file in
     Alcotest.(check string "has updated blob" "bmV3Y29udGVudA==" actual_blob);
     Lwt.return ()
   ;;

--- a/test/service/cases/token.ml
+++ b/test/service/cases/token.ml
@@ -3,11 +3,10 @@ open Alcotest_lwt
 
 module Make (TokenService : Sihl.Token.Sig.SERVICE) = struct
   let create_and_find_token _ () =
-    let ctx = Sihl.Core.Ctx.create () in
-    let* () = Sihl.Repository.Service.clean_all ctx in
-    let* created = TokenService.create ctx ~kind:"test" ~data:"foo" () in
+    let* () = Sihl.Repository.Service.clean_all () in
+    let* created = TokenService.create ~kind:"test" ~data:"foo" () in
     let created_value = Sihl.Token.value created in
-    let* found = TokenService.find ctx created_value in
+    let* found = TokenService.find created_value in
     let () = Alcotest.(check Sihl.Token.alco "Has created session" created found) in
     Lwt.return ()
   ;;

--- a/test/service/mariadb/test.ml
+++ b/test/service/mariadb/test.ml
@@ -13,7 +13,7 @@ module PasswordReset =
 module Queue = Test_case.Queue.Make (Service.Queue)
 module Csrf = Test_case.Csrf.Make (Service.Token) (Service.Session)
 
-let test_suite ctx =
+let test_suite =
   [ Database.test_suite
   ; Token.test_suite
   ; Session.test_suite
@@ -21,9 +21,8 @@ let test_suite ctx =
   ; User.test_suite
   ; Email.test_suite
   ; PasswordReset.test_suite
-  ; (* We need to add the DB Pool to the scheduler context *)
-    Csrf.test_suite (* Put queue tests last because of slowness *)
-  ; Queue.test_suite ctx
+  ; Csrf.test_suite (* Put queue tests last because of slowness *)
+  ; Queue.test_suite
   ]
 ;;
 
@@ -42,9 +41,8 @@ let services =
 let () =
   Unix.putenv "DATABASE_URL" "mariadb://admin:password@127.0.0.1:3306/dev";
   Logs.set_reporter (Sihl.Core.Log.default_reporter ());
-  let ctx = Sihl.Core.Ctx.create () in
   Lwt_main.run
     (let* _ = Sihl.Core.Container.start_services services in
-     let* () = Service.Migration.run_all ctx in
-     run "mariadb" @@ test_suite ctx)
+     let* () = Service.Migration.run_all () in
+     run "mariadb" @@ test_suite)
 ;;

--- a/test/service/memory/test.ml
+++ b/test/service/memory/test.ml
@@ -2,12 +2,12 @@ open Alcotest_lwt
 open Lwt.Syntax
 module Queue = Test_case.Queue.Make (Service.Queue)
 
-let test_suite ctx = [ Queue.test_suite ctx ]
+let test_suite = [ Queue.test_suite ]
 let services = [ Service.Queue.register () ]
 
 let () =
   Logs.set_reporter (Sihl.Core.Log.default_reporter ());
   Lwt_main.run
-    (let* _, ctx = Sihl.Core.Container.start_services services in
-     run "memory" @@ test_suite ctx)
+    (let* _ = Sihl.Core.Container.start_services services in
+     run "memory" @@ test_suite)
 ;;

--- a/test/service/postgresql/test.ml
+++ b/test/service/postgresql/test.ml
@@ -19,9 +19,8 @@ let services =
 let () =
   Unix.putenv "DATABASE_URL" "postgres://admin:password@127.0.0.1:5432/dev";
   Logs.set_reporter (Sihl.Core.Log.default_reporter ());
-  let ctx = Sihl.Core.Ctx.create () in
   Lwt_main.run
     (let* _ = Sihl.Core.Container.start_services services in
-     let* () = Service.Migration.run_all ctx in
+     let* () = Service.Migration.run_all () in
      Alcotest_lwt.run "postgresql" @@ test_suite)
 ;;

--- a/test/unit/queue.ml
+++ b/test/unit/queue.ml
@@ -5,7 +5,7 @@ let should_run_job _ () =
       ~name:"foo"
       ~input_to_string:(fun _ -> None)
       ~string_to_input:(fun _ -> Ok None)
-      ~handle:(fun _ ~input:_ -> Lwt_result.return ())
+      ~handle:(fun ~input:_ -> Lwt_result.return ())
       ~failed:(fun _ -> Lwt_result.return ())
       ()
     |> Sihl.Queue.set_max_tries 3


### PR DESCRIPTION
At the current stage the context was just holding an id that can be
used to trace how services are called. This could be done otherwise
and doesn't require all service functions to take a context.