### PR TITLE
Make Changelog comply to dune-release syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ## [0.1.9] - 2020-11-16
 ### Fixed
 - Get rid of `Core.Ctx.t`


### PR DESCRIPTION
Every release of `sihl` on opam-repository add all the changelog and not only the one for the latest release as it is supposed to.
I haven't tried but I have faced similar issues in `ppx_deriving` so hopefully this fixes the issue in the same way.

See https://github.com/ocaml/opam-repository/pull/17639 for example