### PR TITLE
Fix double POST request CSRF creation

### DIFF
--- a/sihl-web/src/middleware_csrf.ml
+++ b/sihl-web/src/middleware_csrf.ml
@@ -54,6 +54,27 @@ struct
     Lwt.return token
   ;;
 
+  let secret_to_token secret =
+    (* Randomize and scramble secret (XOR with salt) to make a token *)
+    (* Do this to mitigate BREACH attacks: http://breachattack.com/#mitigations *)
+    let secret_length = String.length (Token.value secret) in
+    let salt = Core.Random.bytes ~nr:secret_length in
+    let secret_value = Token.value secret |> String.to_seq |> List.of_seq in
+    let encrypted =
+      match Sihl_core.Utils.Encryption.xor salt secret_value with
+      | None ->
+        Logs.err (fun m -> m "Failed to encrypt CSRF secret");
+        raise @@ Crypto_failed "Failed to encrypt CSRF secret"
+      | Some enc -> enc
+    in
+    encrypted
+    |> List.append salt
+    |> List.to_seq
+    |> String.of_seq
+    (* Make the token transmittable without encoding problems *)
+    |> Base64.encode_string ~alphabet:Base64.uri_safe_alphabet
+  ;;
+
   let m ?not_allowed_handler () =
     let filter handler req =
       (* Check if session already has a secret (token) *)
@@ -71,26 +92,7 @@ struct
           (* Return valid secret from session *)
           | Some secret -> Lwt.return secret)
       in
-      (* Randomize and scramble secret (XOR with salt) to make a token *)
-      (* Do this to mitigate BREACH attacks: http://breachattack.com/#mitigations *)
-      let secret_length = String.length secret.value in
-      let salt = Core.Random.bytes ~nr:secret_length in
-      let secret_value = secret.value |> String.to_seq |> List.of_seq in
-      let encrypted =
-        match Sihl_core.Utils.Encryption.xor salt secret_value with
-        | None ->
-          Logs.err (fun m -> m "Failed to encrypt CSRF secret");
-          raise @@ Crypto_failed "Failed to encrypt CSRF secret"
-        | Some enc -> enc
-      in
-      let token =
-        encrypted
-        |> List.append salt
-        |> List.to_seq
-        |> String.of_seq
-        (* Make the token transmittable without encoding problems *)
-        |> Base64.encode_string ~alphabet:Base64.uri_safe_alphabet
-      in
+      let token = secret_to_token secret in
       let req = set token req in
       (* Don't check for CSRF token in GET requests *)
       let is_safe =
@@ -107,8 +109,7 @@ struct
         | None ->
           (match not_allowed_handler with
           | Some handler -> Lwt.return @@ handler req
-          | None ->
-            Sihl_type.Http_response.(of_plain_text ~status:`Forbidden "") |> Lwt.return)
+          | None -> Opium.Response.(of_plain_text ~status:`Forbidden "") |> Lwt.return)
         | Some value ->
           let decoded = Base64.decode ~alphabet:Base64.uri_safe_alphabet value in
           let decoded =
@@ -142,20 +143,23 @@ struct
               match not_allowed_handler with
               | None ->
                 (* Give 403 if provided secret doesn't match session secret *)
-                Sihl_type.Http_response.(of_plain_text ~status:`Forbidden "")
-                |> Lwt.return
+                Opium.Response.(of_plain_text ~status:`Forbidden "") |> Lwt.return
               | Some handler -> Lwt.return @@ handler req)
             else
               (* Provided secret matches and is valid => Invalidate it so it can't be
                  reused *)
               let* () = TokenService.invalidate ps in
+              (* To allow fetching a new valid token from the context, generate a new one *)
+              let* secret = create_secret session in
+              let token = secret_to_token secret in
+              let req = set token req in
               handler req
           | None ->
             Logs.err (fun m -> m "No token associated with CSRF token");
             (match not_allowed_handler with
             | None ->
               (* Give 403 if provided secret does not exist *)
-              Sihl_type.Http_response.(of_plain_text ~status:`Forbidden "") |> Lwt.return
+              Opium.Response.(of_plain_text ~status:`Forbidden "") |> Lwt.return
             | Some handler -> Lwt.return @@ handler req)))
     in
     Rock.Middleware.create ~name:"csrf" ~filter

--- a/sihl-web/test/csrf.ml
+++ b/sihl-web/test/csrf.ml
@@ -8,6 +8,21 @@ struct
   module Middleware = Sihl_web.Middleware.Csrf.Make (TokenService) (SessionService)
   module SessionMiddleware = Sihl_web.Middleware.Session.Make (SessionService)
 
+  let get_secret tk =
+    tk
+    |> Base64.decode ~alphabet:Base64.uri_safe_alphabet
+    |> Result.get_ok
+    |> String.to_seq
+    |> List.of_seq
+    |> fun tk ->
+    Sihl_core.Utils.Encryption.decrypt_with_salt
+      ~salted_cipher:tk
+      ~salt_length:(List.length tk / 2)
+    |> Option.get
+    |> List.to_seq
+    |> String.of_seq
+  ;;
+
   let apply_middlewares handler =
     let csrf_middleware = Middleware.m () in
     let session_middleware = SessionMiddleware.m () in
@@ -19,12 +34,12 @@ struct
   ;;
 
   let get_request_yields_token _ () =
-    let req = Sihl_type.Http_request.get "" in
     let* () = Sihl_persistence.Repository.clean_all () in
+    let req = Opium.Request.get "" in
     let handler req =
       let token_value = Sihl_web.Middleware.Csrf.find req in
       Alcotest.(check bool "Has CSRF token" true (not @@ String.equal "" token_value));
-      Lwt.return @@ Sihl_type.Http_response.of_plain_text ""
+      Lwt.return @@ Opium.Response.of_plain_text ""
     in
     let wrapped_handler = apply_middlewares handler in
     let* _ = wrapped_handler req in
@@ -32,65 +47,49 @@ struct
   ;;
 
   let get_request_without_token_succeeds _ () =
-    let req = Sihl_type.Http_request.get "" in
     let* () = Sihl_persistence.Repository.clean_all () in
-    let handler _ = Lwt.return @@ Sihl_type.Http_response.of_plain_text "" in
+    let req = Opium.Request.get "" in
+    let handler _ = Lwt.return @@ Opium.Response.of_plain_text "" in
     let wrapped_handler = apply_middlewares handler in
     let* response = wrapped_handler req in
-    let status = Sihl_type.Http_response.status response |> Opium.Status.to_code in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
     Alcotest.(check int "Has status 200" 200 status);
     Lwt.return ()
   ;;
 
   let two_get_requests_yield_same_token _ () =
-    let req = Sihl_type.Http_request.get "" in
     let* () = Sihl_persistence.Repository.clean_all () in
+    (* Do GET to set a token *)
+    let req = Opium.Request.get "" in
     let token_ref1 = ref "" in
     let token_ref2 = ref "" in
     let handler tkn req =
       tkn := Sihl_web.Middleware.Csrf.find req;
-      Lwt.return @@ Sihl_type.Http_response.of_plain_text ""
+      Lwt.return @@ Opium.Response.of_plain_text ""
     in
     let wrapped_handler1 = apply_middlewares (handler token_ref1) in
-    (* Do GET to create token *)
     let* response = wrapped_handler1 req in
-    let cookie = response |> Sihl_type.Http_response.cookies |> List.hd in
-    let cookie_key, cookie_value = cookie.Opium.Cookie.value in
-    let status = Sihl_type.Http_response.status response |> Opium.Status.to_code in
+    let cookie = response |> Opium.Response.cookies |> List.hd in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
     Alcotest.(check int "Has status 200" 200 status);
     (* Do GET with session to get token *)
     let get_req =
-      Sihl_type.Http_request.get "/foo"
-      |> Sihl_type.Http_request.add_cookie (cookie_key, cookie_value)
+      Opium.Request.get "/foo" |> Opium.Request.add_cookie cookie.Opium.Cookie.value
     in
     let wrapped_handler2 = apply_middlewares (handler token_ref2) in
     let* _ = wrapped_handler2 get_req in
-    let get_secret tk =
-      tk
-      |> Base64.decode ~alphabet:Base64.uri_safe_alphabet
-      |> Result.get_ok
-      |> String.to_seq
-      |> List.of_seq
-      |> fun tk ->
-      Sihl_core.Utils.Encryption.decrypt_with_salt
-        ~salted_cipher:tk
-        ~salt_length:(List.length tk / 2)
-      |> Option.get
-      |> List.to_seq
-      |> String.of_seq
-    in
     Alcotest.(
       check string "Same CSRF secret" (get_secret !token_ref1) (get_secret !token_ref2));
     Lwt.return ()
   ;;
 
   let post_request_yields_token _ () =
-    let post_req = Sihl_type.Http_request.post "/foo" in
     let* () = Sihl_persistence.Repository.clean_all () in
+    let post_req = Opium.Request.post "/foo" in
     let handler req =
       let token_value = Sihl_web.Middleware.Csrf.find req in
       Alcotest.(check bool "Has CSRF token" true (not @@ String.equal "" token_value));
-      Lwt.return @@ Sihl_type.Http_response.of_plain_text ""
+      Lwt.return @@ Opium.Response.of_plain_text ""
     in
     let wrapped_handler = apply_middlewares handler in
     let* _ = wrapped_handler post_req in
@@ -98,25 +97,22 @@ struct
   ;;
 
   let post_request_without_token_fails _ () =
-    let post_req = Sihl_type.Http_request.post "/foo" in
     let* () = Sihl_persistence.Repository.clean_all () in
-    let handler _ = Lwt.return @@ Sihl_type.Http_response.of_plain_text "" in
+    let post_req = Opium.Request.post "/foo" in
+    let handler _ = Lwt.return @@ Opium.Response.of_plain_text "" in
     let wrapped_handler = apply_middlewares handler in
     let* response = wrapped_handler post_req in
-    let status = Sihl_type.Http_response.status response |> Opium.Status.to_code in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
     Alcotest.(check int "Has status 403" 403 status);
     Lwt.return ()
   ;;
 
   let post_request_with_invalid_b64_token_fails _ () =
-    let post_req =
-      Sihl_type.Http_request.of_urlencoded
-        ~body:[ "csrf", [ "invalid_token" ] ]
-        "/foo"
-        `POST
-    in
     let* () = Sihl_persistence.Repository.clean_all () in
-    let handler _ = Lwt.return @@ Sihl_type.Http_response.of_plain_text "" in
+    let post_req =
+      Opium.Request.of_urlencoded ~body:[ "csrf", [ "invalid_token" ] ] "/foo" `POST
+    in
+    let handler _ = Lwt.return @@ Opium.Response.of_plain_text "" in
     let wrapped_handler = apply_middlewares handler in
     Lwt.catch
       (fun () -> wrapped_handler post_req |> Lwt.map ignore)
@@ -130,10 +126,10 @@ struct
 
   let post_request_with_invalid_token_fails _ () =
     let post_req =
-      Sihl_type.Http_request.of_urlencoded ~body:[ "csrf", [ "aGVsbG8=" ] ] "/foo" `POST
+      Opium.Request.of_urlencoded ~body:[ "csrf", [ "aGVsbG8=" ] ] "/foo" `POST
     in
     let* () = Sihl_persistence.Repository.clean_all () in
-    let handler _ = Lwt.return @@ Sihl_type.Http_response.of_plain_text "" in
+    let handler _ = Lwt.return @@ Opium.Response.of_plain_text "" in
     let wrapped_handler = apply_middlewares handler in
     Lwt.catch
       (fun () -> wrapped_handler post_req |> Lwt.map ignore)
@@ -145,31 +141,31 @@ struct
   ;;
 
   let post_request_with_nonmatching_token_fails _ () =
-    let req = Sihl_type.Http_request.get "" in
+    (* Do GET to set a token *)
+    let req = Opium.Request.get "" in
     let* () = Sihl_persistence.Repository.clean_all () in
     let token_ref = ref "" in
     let handler req =
       token_ref := Sihl_web.Middleware.Csrf.find req;
-      Lwt.return @@ Sihl_type.Http_response.of_plain_text ""
+      Lwt.return @@ Opium.Response.of_plain_text ""
     in
-    (* Do GET to create token *)
     let wrapped_handler = apply_middlewares handler in
     let* _ = wrapped_handler req in
     (* New request with new session but using old token *)
     let post_req =
-      Sihl_type.Http_request.of_urlencoded ~body:[ "csrf", [ !token_ref ] ] "/foo" `POST
+      Opium.Request.of_urlencoded ~body:[ "csrf", [ !token_ref ] ] "/foo" `POST
     in
-    let handler _ = Lwt.return @@ Sihl_type.Http_response.of_plain_text "" in
+    let handler _ = Lwt.return @@ Opium.Response.of_plain_text "" in
     let wrapped_handler = apply_middlewares handler in
     let* response = wrapped_handler post_req in
-    let status = Sihl_type.Http_response.status response |> Opium.Status.to_code in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
     Alcotest.(check int "Has status 403" 403 status);
     Lwt.return ()
   ;;
 
   let post_request_with_nonexisting_token_fails _ () =
     let post_req =
-      Sihl_type.Http_request.of_urlencoded
+      Opium.Request.of_urlencoded
         ~body:
           [ ( "csrf"
             , [ "qMC8_WY0Kfjxmq5y7vFu2Po8ZsZcW5nocPVkc9Dwj60sZU-8oszGNIKiLKq4WQSuAxXxqxalLU4="
@@ -179,48 +175,90 @@ struct
         `POST
     in
     let* () = Sihl_persistence.Repository.clean_all () in
-    let handler _ = Lwt.return @@ Sihl_type.Http_response.of_plain_text "" in
+    let handler _ = Lwt.return @@ Opium.Response.of_plain_text "" in
     let wrapped_handler = apply_middlewares handler in
     let* response = wrapped_handler post_req in
-    let status = Sihl_type.Http_response.status response |> Opium.Status.to_code in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
     Alcotest.(check int "Has status 403" 403 status);
     Lwt.return ()
   ;;
 
   let post_request_with_valid_token_succeeds _ () =
     (* Do GET to set a token *)
-    let req = Sihl_type.Http_request.get "" in
+    let req = Opium.Request.get "" in
     let* () = Sihl_persistence.Repository.clean_all () in
-    let token_ref = ref "" in
-    let session_req = ref None in
-    let handler req =
-      session_req := Some req;
-      token_ref := Sihl_web.Middleware.Csrf.find req;
-      Lwt.return @@ Sihl_type.Http_response.of_plain_text ""
+    let token_ref1 = ref "" in
+    let token_ref2 = ref "" in
+    let handler tkn req =
+      tkn := Sihl_web.Middleware.Csrf.find req;
+      Lwt.return @@ Opium.Response.of_plain_text ""
     in
-    (* Do GET to create token *)
-    let wrapped_handler = apply_middlewares handler in
+    let wrapped_handler = apply_middlewares @@ handler token_ref1 in
     let* response = wrapped_handler req in
-    let cookie = response |> Sihl_type.Http_response.cookies |> List.hd in
-    let cookie_key, cookie_value = cookie.Opium.Cookie.value in
-    let cookie_header = "Cookie", Format.sprintf "%s=%s" cookie_key cookie_value in
-    let status = Sihl_type.Http_response.status response |> Opium.Status.to_code in
+    let cookie = response |> Opium.Response.cookies |> List.hd in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
     Alcotest.(check int "Has status 200" 200 status);
     (* Do POST to use created token *)
-    let body = Uri.pct_encode @@ "csrf=" ^ !token_ref in
+    let body = Uri.pct_encode @@ "csrf=" ^ !token_ref1 in
     let post_req =
-      Sihl_type.Http_request.of_plain_text ~body "/foo" `POST
-      |> Sihl_type.Http_request.add_header cookie_header
+      Opium.Request.of_plain_text ~body "/foo" `POST
+      |> Opium.Request.add_cookie cookie.Opium.Cookie.value
     in
-    let wrapped_handler = apply_middlewares handler in
+    let wrapped_handler = apply_middlewares @@ handler token_ref2 in
     let* response = wrapped_handler post_req in
-    let status = Sihl_type.Http_response.status response |> Opium.Status.to_code in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
     Alcotest.(check int "Has status 200" 200 status);
-    let req = Option.get !session_req in
-    let session = Sihl_web.Middleware.Session.find req in
-    let* token_id = SessionService.find_value session "csrf" in
-    let token_id = Option.get token_id in
-    let* token = TokenService.find_by_id_opt token_id in
+    let* token = TokenService.find_opt !token_ref1 in
+    Alcotest.(check (option Sihl_type.Token.alco) "Token is invalidated" None token);
+    Lwt.return ()
+  ;;
+
+  let two_post_requests_succeed _ () =
+    (* Do GET to set a token *)
+    let req = Opium.Request.get "" in
+    let* () = Sihl_persistence.Repository.clean_all () in
+    let token_ref1 = ref "" in
+    let token_ref2 = ref "" in
+    let token_ref3 = ref "" in
+    let handler tkn req =
+      tkn := Sihl_web.Middleware.Csrf.find req;
+      Lwt.return @@ Opium.Response.of_plain_text ""
+    in
+    let wrapped_handler = apply_middlewares @@ handler token_ref1 in
+    let* response = wrapped_handler req in
+    let cookie = response |> Opium.Response.cookies |> List.hd in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
+    Alcotest.(check int "Has status 200" 200 status);
+    (* Do first POST *)
+    let body = Uri.pct_encode @@ "csrf=" ^ !token_ref1 in
+    let post_req =
+      Opium.Request.of_plain_text ~body "/foo" `POST
+      |> Opium.Request.add_cookie cookie.Opium.Cookie.value
+    in
+    let wrapped_handler = apply_middlewares @@ handler token_ref2 in
+    let* response = wrapped_handler post_req in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
+    Alcotest.(check int "Has status 200" 200 status);
+    let* token = TokenService.find_opt !token_ref1 in
+    Alcotest.(check (option Sihl_type.Token.alco) "Token is invalidated" None token);
+    (* Do second POST *)
+    (* TODO [aerben] do opium everywhere *)
+    Alcotest.(
+      check
+        bool
+        "New token generated after POST"
+        false
+        (String.equal (get_secret !token_ref1) (get_secret !token_ref2)));
+    let body = Uri.pct_encode @@ "csrf=" ^ !token_ref2 in
+    let post_req =
+      Opium.Request.of_plain_text ~body "/foo" `POST
+      |> Opium.Request.add_cookie @@ cookie.Opium.Cookie.value
+    in
+    let wrapped_handler = apply_middlewares @@ handler token_ref3 in
+    let* response = wrapped_handler post_req in
+    let status = Opium.Response.status response |> Opium.Status.to_code in
+    Alcotest.(check int "Has status 200" 200 status);
+    let* token = TokenService.find_opt !token_ref2 in
     Alcotest.(check (option Sihl_type.Token.alco) "Token is invalidated" None token);
     Lwt.return ()
   ;;
@@ -229,7 +267,7 @@ struct
     [ ( "csrf"
       , [ test_case "get request yields CSRF token" `Quick get_request_yields_token
         ; test_case
-            "two get requests_yield_same_token"
+            "two get requests yield same CSRF token"
             `Quick
             two_get_requests_yield_same_token
         ; test_case
@@ -261,6 +299,10 @@ struct
             "post request with valid CSRF token succeeds"
             `Quick
             post_request_with_valid_token_succeeds
+        ; test_case
+            "two post requests with a valid CSRF token succeed"
+            `Quick
+            two_post_requests_succeed
         ] )
     ]
   ;;


### PR DESCRIPTION
Cleaned up the tests a little to use modern API. Also replaced `Sihl_type.Http_*` with `Opium`.