### PR TITLE
Make sure that calls like read_string () and read_secret () work ever…

### DIFF
--- a/sihl/src/core_app.ml
+++ b/sihl/src/core_app.ml
@@ -79,8 +79,7 @@ let run' ?(commands = []) ?(log_reporter = Core_log.default_reporter) ?args app 
         , Core_container.Service.configuration service ))
       app.services
   in
-  let* file_configuration = Core_configuration.read_env_file () in
-  Core_configuration.store @@ Option.value file_configuration ~default:[];
+  let () = Core_configuration.load_env_file () in
   let* () = app.before_start () in
   let configuration_commands = Core_configuration.commands configurations in
   Logger.info (fun m -> m "Setup service commands");

--- a/sihl/src/core_configuration.mli
+++ b/sihl/src/core_configuration.mli
@@ -74,9 +74,15 @@ val env_files_path : unit -> string option
     [env_files_path] and returns the key-value pairs as [data]. If [SIHL_ENV] is
     set to [test], [.env.test] is read. Otherwise [.env] is read. If the file
     doesn't exist or the directory containing the file can't be found, [None] is
-    returned. *)
+    returned.
 
-val read_env_file : unit -> data option Lwt.t
+    If you just want to access configuration values, use the read functions
+    instead. Every time you call [read_env_file] the file is read from disk. *)
+val read_env_file : unit -> data option
+
+(** [load_env_file ()] reads an [.env] file using {!read_env_file} and stores
+    its contents into the environment variables. *)
+val load_env_file : unit -> unit
 
 (** [read schema] returns the decoded, statically typed version of configuration
     [t] of the [schema]. This is used in services to declaratively define a

--- a/sihl/test/core_configuration.ml
+++ b/sihl/test/core_configuration.ml
@@ -115,7 +115,7 @@ let read_schema _ () =
 ;;
 
 let read_env_file_non_existing _ () =
-  let* data = Sihl.Configuration.read_env_file () in
+  let data = Sihl.Configuration.read_env_file () in
   let data = Option.value data ~default:[] in
   Alcotest.(check (list string) "Returns empty keys" [] (List.map fst data));
   Alcotest.(check (list string) "Returns empty values" [] (List.map snd data));
@@ -138,7 +138,7 @@ let read_env_file switch () =
         let envs = List.map2 (fun k v -> k ^ "=" ^ v) keys values in
         Lwt_list.iter_s (Lwt_io.write_line ch) envs)
   in
-  let* data = Sihl.Configuration.read_env_file () in
+  let data = Sihl.Configuration.read_env_file () in
   let data = Option.value data ~default:[] in
   Alcotest.(
     check (list string) "Returns keys" (List.rev keys) (List.map fst data));


### PR DESCRIPTION
…ywhere

So far reading values from the .env files was only guaranteed to be
correct after the Sihl app was started. Sometimes it is useful to read
values from it before starting the app.

Fix #410