### PR TITLE
Remove session middleware and simplify session handling code

### DIFF
--- a/sihl/src/index.mld
+++ b/sihl/src/index.mld
@@ -404,14 +404,6 @@ Since HTTP driven applications are stateless, sessions provide a way to store in
 
 Sihl ships with a cookie-based session implementation.
 
-{3 Installation}
-
-Add {!val:Sihl.Web.Middleware.session} to your list of middlewares. The session middleware is enabled by default for site routes in [routes/site.ml].
-
-{[
-let middlewares = [ Sihl.Web.Middleware.session () ]
-]}
-
 {3 Usage}
 
 Use {!Sihl.Web.Session} to handle sessions.
@@ -421,10 +413,13 @@ In order to set session values create a response first:
 {[
 let handler _ =
   let resp = Opium.Response.of_plain_text "some response" in
-  Lwt.return @@ Sihl.Web.Session.set ("user_id", Some "4882") resp
+  Lwt.return @@ Sihl.Web.Session.set [("user_id", Some "4882")] resp
 ]}
 
+Note that setting the session like this overrides any previously set sessions. You should not chain {!val:Sihl.Web.Session.set} or touch the session cookie manually.
+
 To read a session value:
+
 {[
 let handler req =
   let user_id = Sihl.Web.Session.find "user_id" req in
@@ -432,8 +427,6 @@ let handler req =
   | Some user_id -> (* fetch user and do stuff *)
   | None -> Opium.Response.of_plain_text "User not logged in"
 ]}
-
-To delete a session value use [None] as value.
 
 {3 Limitations}
 

--- a/sihl/src/sihl.ml
+++ b/sihl/src/sihl.ml
@@ -83,8 +83,6 @@ module Web = struct
   end
 
   module Session = struct
-    exception Session_not_found = Web_session.Session_not_found
-
     let find = Web_session.find
     let set = Web_session.set
   end
@@ -107,7 +105,6 @@ module Web = struct
     let form = Web_form.middleware
     let id = Web_id.middleware
     let json = Web_json.middleware
-    let session = Web_session.middleware
     let static_file = Web_static.middleware
     let user = Web_user.middleware
   end

--- a/sihl/src/sihl.mli
+++ b/sihl/src/sihl.mli
@@ -94,10 +94,37 @@ module Web : sig
   end
 
   module Session : sig
-    exception Session_not_found
+    (** [find ?cookie_key ?secret key request] returns the value that is
+        associated to the [key] in the current session of the [request].
 
-    val find : string -> Opium.Request.t -> string option
-    val set : string * string option -> Opium.Response.t -> Opium.Response.t
+        [cookie_key] is the name of the session cookie. By default, the value is
+        [_session].
+
+        [secret] is the secret used to sign the session cookie. By default,
+        [SIHL_SECRET] is used. *)
+    val find
+      :  ?cookie_key:string
+      -> ?secret:string
+      -> string
+      -> Opium.Request.t
+      -> string option
+
+    (** [set ?cookie_key ?secret data response] returns a response that has
+        [data] associated to the current session by setting the session cookie
+        of the response. [set] replaces the current session.
+
+        [cookie_key] is the name of the session cookie. By default, the value is
+        [_session]. If there is a session cookie already present it gets
+        replaced.
+
+        [secret] is the secret used to sign the session cookie. By default,
+        [SIHL_SECRET] is used. *)
+    val set
+      :  ?cookie_key:string
+      -> ?secret:string
+      -> (string * string) list
+      -> Opium.Response.t
+      -> Opium.Response.t
   end
 
   module User : sig
@@ -184,26 +211,6 @@ module Web : sig
     val form : Rock.Middleware.t
     val id : Rock.Middleware.t
     val json : Rock.Middleware.t
-
-    (** [session ?cookie_key ?secret ()] returns a middleware that reads and
-        stores session values. The actual session values are stored in a signed
-        cookie. Be aware of the limitations of this technique. Firstly, make
-        sure that the session value does not exceed 4KB. Secondly, the client is
-        able to read the session values. If you need to store a large amount of
-        data, use the [sihl-cache] package and store the key in the session
-        cookie.
-
-        [cookie_key] is the key of the session cookie. By default, the value is
-        [_session].
-
-        [secret] is a secret string that is used to sign cookies. By default
-        [SIHL_SECRET] is used. *)
-    val session
-      :  ?cookie_key:string
-      -> ?secret:string
-      -> unit
-      -> Rock.Middleware.t
-
     val static_file : unit -> Rock.Middleware.t
 
     (** [user ?key find_user] returns a middleware that sets the user based on

--- a/sihl/src/web_session.ml
+++ b/sihl/src/web_session.ml
@@ -4,12 +4,9 @@ module Logs = (val Logs.src_log log_src : Logs.LOG)
 module Map = Map.Make (String)
 
 module Session = struct
-  type t =
-    { data : string Map.t
-    ; should_set_cookie : bool
-    }
+  type t = string Map.t
 
-  let create should_set_cookie = { data = Map.empty; should_set_cookie }
+  let empty = Map.empty
 
   let of_yojson yojson =
     let open Yojson.Safe.Util in
@@ -19,13 +16,10 @@ module Session = struct
       with
       | _ -> None
     in
-    session_list
-    |> Option.map List.to_seq
-    |> Option.map Map.of_seq
-    |> Option.map (fun data -> { data; should_set_cookie = false })
+    session_list |> Option.map List.to_seq |> Option.map Map.of_seq
   ;;
 
-  let to_yojson { data = session; _ } =
+  let to_yojson session =
     `Assoc
       (session
       |> Map.to_seq
@@ -44,86 +38,18 @@ module Session = struct
     let open Sexplib0.Sexp_conv in
     let open Sexplib0.Sexp in
     let data =
-      session.data
+      session
       |> Map.to_seq
       |> List.of_seq
       |> sexp_of_list (sexp_of_pair sexp_of_string sexp_of_string)
     in
-    List
-      [ List [ Atom "data"; data ]
-      ; List
-          [ Atom "should_set_cookie"; sexp_of_bool session.should_set_cookie ]
-      ]
+    List [ List [ Atom "data"; data ] ]
   ;;
 end
-
-module SessionChange = struct
-  type t = string option Map.t
-
-  let empty = Map.empty
-
-  let merge Session.{ data = session; should_set_cookie } t =
-    let data =
-      Map.merge
-        (fun _ session change ->
-          match session, change with
-          | _, Some (Some change) -> Some change
-          | _, Some None -> None
-          | Some session, None -> Some session
-          | None, None -> None)
-        session
-        t
-    in
-    Session.{ data; should_set_cookie }
-  ;;
-
-  let to_sexp t =
-    t
-    |> Map.to_seq
-    |> List.of_seq
-    |> Sexplib0.Sexp_conv.(
-         sexp_of_list
-           (sexp_of_pair sexp_of_string (sexp_of_option sexp_of_string)))
-  ;;
-end
-
-module Env = struct
-  let key : Session.t Opium.Context.key =
-    Opium.Context.Key.create ("session", Session.to_sexp)
-  ;;
-
-  let key_session_change : SessionChange.t Opium.Context.key =
-    Opium.Context.Key.create ("session change", SessionChange.to_sexp)
-  ;;
-end
-
-exception Session_not_found
-
-let find key req =
-  let session =
-    try Opium.Context.find_exn Env.key req.Opium.Request.env with
-    | _ ->
-      Logs.err (fun m -> m "No session found");
-      Logs.info (fun m -> m "Have you applied the session middleware?");
-      raise @@ Session_not_found
-  in
-  Map.find_opt key session.data
-;;
-
-let set (key, value) resp =
-  let change =
-    match Opium.Context.find Env.key_session_change resp.Opium.Response.env with
-    | Some change -> Map.add key value change
-    | None -> SessionChange.empty |> Map.add key value
-  in
-  let env = resp.Opium.Response.env in
-  let env = Opium.Context.add Env.key_session_change change env in
-  { resp with env }
-;;
 
 let decode_session cookie_key signed_with req =
   match Opium.Request.cookie ~signed_with cookie_key req with
-  | None -> Session.create true
+  | None -> None
   | Some cookie_value ->
     (match Session.of_json cookie_value with
     | None ->
@@ -137,49 +63,30 @@ let decode_session cookie_key signed_with req =
             "Maybe the cookie key '%s' collides with a cookie issued by \
              someone else. Try to change the cookie key."
             cookie_key);
-      Session.create true
-    | Some session -> session)
+      None
+    | Some session -> Some session)
 ;;
 
-let persist_session current_session signed_with cookie_key resp =
-  let session_change =
-    Opium.Context.find Env.key_session_change resp.Opium.Response.env
-  in
-  let cookie =
-    match current_session.Session.should_set_cookie, session_change with
-    | true, Some session_change ->
-      let session = SessionChange.merge current_session session_change in
-      let cookie_value = Session.to_json session in
-      Some (cookie_key, cookie_value)
-    | true, None ->
-      let cookie_value = Session.to_json (Session.create true) in
-      Some (cookie_key, cookie_value)
-    | false, Some session_change ->
-      let session = SessionChange.merge current_session session_change in
-      let cookie_value = Session.to_json session in
-      Some (cookie_key, cookie_value)
-    | false, None -> None
-  in
-  match cookie with
-  | None -> resp
-  | Some cookie ->
-    Opium.Response.add_cookie_or_replace ~sign_with:signed_with cookie resp
-;;
-
-let middleware
+let find
     ?(cookie_key = "_session")
     ?(secret = Core_configuration.read_secret ())
-    ()
+    key
+    req
   =
-  let open Lwt.Syntax in
-  let filter handler req =
-    let signed_with = Opium.Cookie.Signer.make secret in
-    let session = decode_session cookie_key signed_with req in
-    let env = req.Opium.Request.env in
-    let env = Opium.Context.add Env.key session env in
-    let req = { req with env } in
-    let* resp = handler req in
-    Lwt.return @@ persist_session session signed_with cookie_key resp
-  in
-  Rock.Middleware.create ~name:"session" ~filter
+  let signed_with = Opium.Cookie.Signer.make secret in
+  let session = decode_session cookie_key signed_with req in
+  Option.bind session (Map.find_opt key)
+;;
+
+let set
+    ?(cookie_key = "_session")
+    ?(secret = Core_configuration.read_secret ())
+    session
+    resp
+  =
+  let signed_with = Opium.Cookie.Signer.make secret in
+  let session = session |> List.to_seq |> Map.of_seq in
+  let cookie_value = Session.to_json session in
+  let cookie = cookie_key, cookie_value in
+  Opium.Response.add_cookie_or_replace ~sign_with:signed_with cookie resp
 ;;


### PR DESCRIPTION
This is an approach without using middlewares. It simplifies quite a bit, what do you think?
We could use the same approach for the `htmx` and maybe the `form` middlewares,