### PR TITLE
restructure caqti response found rows

### DIFF
--- a/sihl-user/src/user_repo.ml
+++ b/sihl-user/src/user_repo.ml
@@ -145,8 +145,15 @@ struct
         FROM user_users |sql}
   ;;
 
+  let found_rows_query = {sql| SELECT COUNT(*) FROM user_users |sql}
+
   let requests =
-    Sihl.Database.prepare_requests search_query filter_fragment "id" user
+    Sihl.Database.prepare_requests
+      search_query
+      found_rows_query
+      filter_fragment
+      "id"
+      user
   ;;
 
   let search sort filter limit =
@@ -357,8 +364,15 @@ struct
         FROM user_users |sql}
   ;;
 
+  let found_rows_query = {sql| SELECT COUNT(*) FROM user_users |sql}
+
   let requests =
-    Sihl.Database.prepare_requests search_query filter_fragment "id" user
+    Sihl.Database.prepare_requests
+      search_query
+      found_rows_query
+      filter_fragment
+      "id"
+      user
   ;;
 
   let search sort filter limit =

--- a/sihl-user/src/user_repo.ml
+++ b/sihl-user/src/user_repo.ml
@@ -1,4 +1,3 @@
-open Lwt.Syntax
 module Database = Sihl.Database
 module Cleaner = Sihl.Cleaner
 module Migration = Sihl.Database.Migration
@@ -150,24 +149,10 @@ struct
     Sihl.Database.prepare_requests search_query filter_fragment "id" user
   ;;
 
-  let found_rows_request =
-    Caqti_request.find
-      ~oneshot:true
-      Caqti_type.unit
-      Caqti_type.int
-      "SELECT COUNT(*) FROM user_users"
-  ;;
-
   let search sort filter limit =
     Sihl.Database.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
-        let* result =
-          Sihl.Database.run_request connection requests sort filter limit
-        in
-        let* amount =
-          Connection.find found_rows_request () |> Lwt.map Result.get_ok
-        in
-        Lwt.return (result, amount))
+        Sihl.Database.run_request connection requests sort filter limit)
   ;;
 
   let get_request =
@@ -376,24 +361,10 @@ struct
     Sihl.Database.prepare_requests search_query filter_fragment "id" user
   ;;
 
-  let found_rows_request =
-    Caqti_request.find
-      ~oneshot:true
-      Caqti_type.unit
-      Caqti_type.int
-      "SELECT COUNT(*) FROM user_users"
-  ;;
-
   let search sort filter limit =
     Sihl.Database.query (fun connection ->
         let module Connection = (val connection : Caqti_lwt.CONNECTION) in
-        let* result =
-          Sihl.Database.run_request connection requests sort filter limit
-        in
-        let* amount =
-          Connection.find found_rows_request () |> Lwt.map Result.get_ok
-        in
-        Lwt.return (result, amount))
+        Sihl.Database.run_request connection requests sort filter limit)
   ;;
 
   let get_request =

--- a/sihl/src/contract_database.ml
+++ b/sihl/src/contract_database.ml
@@ -12,11 +12,13 @@ module type Sig = sig
     :  string
     -> string
     -> string
+    -> string
     -> 'a Caqti_type.t
     -> (int, 'a, [ `Many | `One | `Zero ]) Caqti_request.t
        * (int, 'a, [ `Many | `One | `Zero ]) Caqti_request.t
        * (string * int, 'a, [ `Many | `One | `Zero ]) Caqti_request.t
        * (string * int, 'a, [ `Many | `One | `Zero ]) Caqti_request.t
+       * (unit, int, [< `Many | `One | `Zero > `One ]) Caqti_request.t
 
   val run_request
     :  (module Caqti_lwt.CONNECTION)
@@ -24,6 +26,7 @@ module type Sig = sig
        * ('a, 'b, [< `Many | `One | `Zero ]) Caqti_request.t
        * ('c * 'a, 'b, [< `Many | `One | `Zero ]) Caqti_request.t
        * ('c * 'a, 'b, [< `Many | `One | `Zero ]) Caqti_request.t
+       * (unit, int, [< `One ]) Caqti_request.t
     -> [< `Asc | `Desc ]
     -> 'c option
     -> 'a

--- a/sihl/src/contract_database.ml
+++ b/sihl/src/contract_database.ml
@@ -27,7 +27,7 @@ module type Sig = sig
     -> [< `Asc | `Desc ]
     -> 'c option
     -> 'a
-    -> 'b list Lwt.t
+    -> ('b list * int) Lwt.t
 
   (** [raise_error err] raises a printable caqti error [err] .*)
   val raise_error : ('a, Caqti_error.t) Result.t -> 'a


### PR DESCRIPTION
use caqti response returned count functionality instead of row count request.

@jerben I think it still possible to optimise it even more by using the response of `Connection.call` and handle `collect_list` and `returned_count` at once.