### PR TITLE
Add a dependency on containers.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -28,6 +28,7 @@ Sihl is a batteries-included web framework. Thanks to the modular architecture, 
   (conformist (>= 0.6.0))
   (dune-build-info (>= 2.8.4))
   (tsort (>= 2.0.0))
+  (containers (>= 2.7))
   (logs (>= 0.7.0))
   (fmt (>= 0.8.8))
   (bos (>= 0.2.0))

--- a/sihl.opam
+++ b/sihl.opam
@@ -18,6 +18,7 @@ depends: [
   "conformist" {>= "0.6.0"}
   "dune-build-info" {>= "2.8.4"}
   "tsort" {>= "2.0.0"}
+  "containers" {>= "2.7"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.8"}
   "bos" {>= "0.2.0"}

--- a/sihl/src/dune
+++ b/sihl/src/dune
@@ -3,7 +3,7 @@
  (public_name sihl)
  (libraries sexplib fmt fmt.tty logs logs.fmt lwt lwt.unix tsort conformist
    base64 yojson ppx_deriving_yojson.runtime safepass ptime ptime.clock.os
-   jwto uuidm opium caqti-lwt str dune-build-info bos)
+   jwto uuidm opium caqti-lwt str dune-build-info bos containers)
  (preprocess
   (pps ppx_fields_conv ppx_deriving_yojson ppx_deriving.eq ppx_deriving.show
     ppx_deriving.make ppx_sexp_conv lwt_ppx)))


### PR DESCRIPTION
sihl uses quite a few functions from the [containers](https://opam.ocaml.org/packages/containers) library but doesn't specify it as a dependency. That used to work because it also depends on [tsort](https://opam.ocaml.org/packages/tsort/), and tsort <= 2.0.0 depends on containers.

In [2.1.0](https://github.com/ocaml/opam-repository/pull/19173) I removed the dependency on containers, which led to [cascade build failures](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/d5d524899cc79a4cd2891473831fe1a97e0a9b72).

I [fixed](https://github.com/ocaml/opam-repository/pull/19173/commits/d2b71157ba31284c12800cfbb117c853492ee8de) that in the PR so that the repo can be in a consistent state, but it also needs to be fixed upstream.